### PR TITLE
fix: remove `@ausias-armesto` from non CI related changes as a CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,7 +16,7 @@
 /src/ @qYuQianchen @jeandemeusy
 
 # Build and configuration
-*.nix @tolbrino @Teebor-Choka
+*.nix @tolbrino @Teebor-Choka @ausias-armesto
 *.toml @Teebor-Choka @NumberFour8 @QYuQianchen
 
 # Secure changes to critical files


### PR DESCRIPTION
Update CODE Owners file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code ownership configuration: removed an owner from the default and source ownership entries.
  * Reordered entries in the build/configuration ownership section to adjust precedence.
  * No changes to workflows, configuration semantics, or public API surface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->