### PR TITLE
fix: Fixes several pipeline errors

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,8 @@ jobs:
             debug_command: nix run -L .#hopli-dev-docker-build-and-upload
     permissions:
       contents: read
+      security-events: write
+      id-token: write
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       version_type: "commit"
@@ -37,6 +39,7 @@ jobs:
       build_command: ${{ matrix.command }}
       build_debug_command: ${{ matrix.debug_command }}
       docker_image_name: "hopli"
+      fail_on_scan_vulnerabilities: ${{ vars.FAIL_ON_SCAN_VULNERABILITIES }}
     secrets:
       gcp_service_account: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY}}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -21,6 +21,8 @@ jobs:
             command: nix run -L .#hopli-docker-build-and-upload
     permissions:
       contents: read
+      security-events: write
+      id-token: write
     with:
       source_branch: ${{ github.event.pull_request.base.ref }}
       version_type: "pr"
@@ -29,6 +31,7 @@ jobs:
       build_file: "Cargo.toml"
       build_command: ${{ matrix.command }}
       docker_image_name: "hopli"
+      fail_on_scan_vulnerabilities: ${{ vars.FAIL_ON_SCAN_VULNERABILITIES }}
     secrets:
       gcp_service_account: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY}}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: "Next version type"
+        description: Version type after release
         required: true
         type: choice
         default: "patch"
@@ -36,6 +36,7 @@ jobs:
       build_file: "Cargo.toml"
       build_command: ${{ matrix.command }}
       docker_image_name: "hopli"
+      fail_on_scan_vulnerabilities: ${{ vars.FAIL_ON_SCAN_VULNERABILITIES }}
     secrets:
       gcp_service_account: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY}}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -47,6 +48,8 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/build-docker-manifest.yaml@build-docker-manifest-v1
     permissions:
       contents: read
+      security-events: write
+      id-token: write
     with:
       version_type: "release"
       docker_image_name: "hopli"
@@ -90,14 +93,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout hoprnet repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-        with:
-          persist-credentials: false
-          ref: ${{ github.ref }}
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@18bf0070b97ef2e46488c946d2706a08272d1dd6 # release-version-v1
+        uses: hoprnet/hopr-workflows/actions/release-version@dc45f200b11bbc192a8a0766f22d1e6ba680e8b1 # release-version-v1
         with:
+          source_branch: ${{ github.ref_name }}
           file: Cargo.toml
           release_type: "${{ inputs.release_type }}"
           zulip_api_key: ${{ secrets.ZULIP_API_KEY }}
@@ -105,3 +104,4 @@ jobs:
           zulip_channel: "Hoprd"
           zulip_topic: "Releases"
           gcp_service_account: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY}}
+          github_token: ${{ secrets.GH_RUNNER_TOKEN }}


### PR DESCRIPTION
- The close release workflow is using the permissions of the invoker to bump the version in main branch directly. It needs to use the Hopr bot token which has an exclusion to do commits directly in main branch.
- The build, merge and release pipeline do not have proper permissions
- Added the skip of docker image vulnerability


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build security scanning with configurable vulnerability checks across workflows
  * Streamlined release workflow with improved version management and token handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->