### PR TITLE
fix: missing ca certificates in docker images

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,6 +3,7 @@ ignore = [
   "RUSTSEC-2024-0436", # 'paste' dependency in 'alloy' [unmaintained]
   "RUSTSEC-2024-0388", # 'derivative' in 'alloy' [unmaintained],
   "RUSTSEC-2025-0073", # 'alloy-dyn-abi' in 'alloy' - will be removed in 4.0
+  "RUSTSEC-2026-0097", # Rand is unsound with a custom logger using `rand::rng()`
 ]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"

--- a/flake.nix
+++ b/flake.nix
@@ -108,6 +108,12 @@
             inherit builders src depsSrc rev buildPlatform nixLib;
           };
 
+          dockerEnv = [
+            "ETHERSCAN_API_KEY=placeholder"
+            "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            "SSL_CERT_DIR=${pkgs.cacert}/etc/ssl/certs"
+          ];
+
           profileDeps = with pkgs; [
             gdb
             # FIXME: heaptrack would be useful, but it adds 700MB to the image size (unpacked)
@@ -136,25 +142,25 @@
               name = "hopli";
               extraContents = [ hopliPackages.binary-hopli-x86_64-linux ];
               Entrypoint = [ "/bin/hopli" ];
-              env = [ "ETHERSCAN_API_KEY=placeholder" ];
+              env = dockerEnv;
             };
             docker-hopli-aarch64-linux = nixLib.mkDockerImage {
               name = "hopli";
               extraContents = [ hopliPackages.binary-hopli-aarch64-linux ];
               Entrypoint = [ "/bin/hopli" ];
-              env = [ "ETHERSCAN_API_KEY=placeholder" ];
+              env = dockerEnv;
             };
             docker-hopli-x86_64-linux-dev = nixLib.mkDockerImage {
               name = "hopli";
               extraContents = [ hopliPackages.binary-hopli-x86_64-linux-dev ];
               Entrypoint = [ "/bin/hopli" ];
-              env = [ "ETHERSCAN_API_KEY=placeholder" ];
+              env = dockerEnv;
             };
             docker-hopli-x86_64-linux-profile = nixLib.mkDockerImage {
               name = "hopli";
               extraContents = [ hopliPackages.binary-hopli-x86_64-linux ] ++ profileDeps;
               Entrypoint = [ "/bin/hopli" ];
-              env = [ "ETHERSCAN_API_KEY=placeholder" ];
+              env = dockerEnv;
             };
           };
 


### PR DESCRIPTION
Sets the SSL certificate path in the docker images.

Fixes #46 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated Docker build environment handling to centralize API key and SSL certificate settings across image builds, improving maintainability.
  * Updated security audit configuration to ignore a specific advisory in the audit tool, reducing noise during vulnerability checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->