### PR TITLE
chore(deps): use hopr-bindings from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,7 +2317,7 @@ dependencies = [
  "env_logger",
  "hex",
  "hex-literal",
- "hopr-bindings 4.7.4",
+ "hopr-bindings",
  "hopr-crypto-keypair",
  "hopr-types",
  "lazy_static",
@@ -2354,26 +2354,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-bindings"
-version = "4.7.4"
-source = "git+https://github.com/hoprnet/contracts?branch=main#cba2eaab72158a83438dde261a45654c3872de8b"
-dependencies = [
- "alloy",
- "anyhow",
- "const_format",
- "hex-literal",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "hopr-crypto-keypair"
 version = "0.5.3"
-source = "git+https://github.com/hoprnet/hoprnet?branch=master#131da099525143c8aa1e6dbfd1d829b8f2c39bb4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=master#541845b8e05165dd9fe4ce5c3e3c680e3a415223"
 dependencies = [
  "hex",
  "hopr-platform",
@@ -2390,7 +2373,7 @@ dependencies = [
 [[package]]
 name = "hopr-platform"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=master#131da099525143c8aa1e6dbfd1d829b8f2c39bb4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=master#541845b8e05165dd9fe4ce5c3e3c680e3a415223"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2418,7 +2401,7 @@ dependencies = [
  "generic-array 1.3.5",
  "hex",
  "hex-literal",
- "hopr-bindings 4.7.3",
+ "hopr-bindings",
  "k256",
  "lazy_static",
  "libp2p-identity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tracing-subscriber = { version = "0.3.20", features = [
 uuid = { version = "1.18.1" }
 url = { version = "2.5.7", features = ["serde"] }
 
-hopr-bindings = { git = "https://github.com/hoprnet/contracts", branch = "main" }
+hopr-bindings = "4.7"
 hopr-types = { version = "1.5", features = [
   "chain",
   "crypto",


### PR DESCRIPTION
Updated hopr-bindings to use version from crates.io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded `hopr-bindings` dependency from a Git-based branch source to a stable published version, improving build consistency and dependency resolution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->