### PR TITLE
fix: Disable x86_64-darwin building

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,9 +30,6 @@ jobs:
           - architecture: aarch64-linux
             runner: self-hosted-hoprnet-bigger
             build_command: nix build -L .#binary-hopli-aarch64-linux
-          - architecture: x86_64-darwin
-            runner: macos-15-intel
-            build_command: nix build -L .#binary-hopli-x86_64-darwin
           - architecture: aarch64-darwin
             runner: macos-15-xlarge
             build_command: nix build -L .#binary-hopli-aarch64-darwin


### PR DESCRIPTION
Temporary disable of x86_64-darwin build on release until #56 is fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed macOS Intel binary builds from the release process. Pre-built binaries will no longer be provided for macOS Intel systems; users on these machines may need to build from source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->