### PR TITLE
fix(ci): migrate codecov to OIDC and bump to workflow-tests-v6

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: branches-${{ github.ref_name }}
@@ -17,6 +16,8 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
+    permissions:
+      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
+    permissions:
+      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # zizmor: ignore[excessive-permissions]
 
 concurrency:
   group: branches-${{ github.ref_name }}
@@ -16,8 +17,6 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    permissions:
-      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write # zizmor: ignore[excessive-permissions]
 
 concurrency:
   group: branches-${{ github.ref_name }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: branches-${{ github.ref_name }}
@@ -16,7 +17,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}
       enable_unit_tests: false
@@ -26,4 +27,3 @@ jobs:
       runner_unit: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
@@ -90,7 +91,7 @@ jobs:
 
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true
@@ -103,7 +104,6 @@ jobs:
       test_timeout: 60
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   build-candidate-binaries:
     name: Build Candidate Binaries

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write # zizmor: ignore[excessive-permissions]
 
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
@@ -91,6 +90,8 @@ jobs:
 
   tests:
     name: Test
+    permissions:
+      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -90,6 +90,8 @@ jobs:
 
   tests:
     name: Test
+    permissions:
+      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # zizmor: ignore[excessive-permissions]
 
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
@@ -90,8 +91,6 @@ jobs:
 
   tests:
     name: Test
-    permissions:
-      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}


### PR DESCRIPTION
## Summary

- Migrate Codecov upload from global upload token to GitHub Actions OIDC (`use_oidc: true`)
- Bump `tests.yaml` pin to `workflow-tests-v6` (`798d791de5c5485c3043049781dfd0938539a36a`)
- Remove `CODECOV_TOKEN` secret passthrough — no longer needed with OIDC
- Move `id-token: write` from workflow-level to only the `tests`/`coverage` job to avoid overly broad permissions (Zizmor fix)

Depends on: https://github.com/hoprnet/hopr-workflows/pull/88