### PR TITLE
feat: Update hopr-types to v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,10 +1149,12 @@ dependencies = [
  "elliptic-curve 0.14.1",
  "ff 0.14.0",
  "group 0.14.0",
+ "hash2curve",
  "num-traits",
  "rand_core 0.10.1",
  "serde",
  "serdect 0.4.3",
+ "sha2 0.11.0",
  "subtle",
  "taceo-ark-babyjubjub",
 ]
@@ -1280,7 +1282,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -1669,7 +1671,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -1697,7 +1699,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "typenum",
 ]
 
@@ -1921,7 +1923,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -2086,7 +2088,7 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff 0.13.1",
- "generic-array 0.14.7",
+ "generic-array",
  "group 0.13.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
@@ -2409,18 +2411,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
-dependencies = [
- "rustversion",
- "serde_core",
- "typenum",
- "zeroize",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2642,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.9.1"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1afa8766e3b7c9ac7f770e5330bb08f91af6db385a1b388239814fc03f7c171a"
+checksum = "f2b7679591cc56238e934139e1e46f57e5df1d688e059a034fa0e38a5ce09b7c"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2660,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.11.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ae257f1e5222f2bebe37af0f14eb46337bd593d3ac3778fef2c82db0fa1a3e"
+checksum = "e24293a5ce7289056c4e01b8d91beebc8663cdcca8ffbc24d847f3f22af4f274"
 dependencies = [
  "aes",
  "anyhow",
@@ -2680,11 +2670,12 @@ dependencies = [
  "curve25519-dalek 5.0.0",
  "digest 0.11.3",
  "ed25519-dalek 3.0.0",
+ "elliptic-curve 0.14.1",
  "float-cmp",
- "generic-array 1.4.3",
  "hash2curve",
  "hex-literal",
  "hopr-bindings",
+ "hybrid-array",
  "k256 0.14.0",
  "lazy_static",
  "libp2p-identity",
@@ -2759,6 +2750,7 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "serde",
  "subtle",
  "typenum",
  "zeroize",
@@ -4551,7 +4543,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct 0.2.0",
  "der 0.7.10",
- "generic-array 0.14.7",
+ "generic-array",
  "pkcs8 0.10.2",
  "serdect 0.2.0",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ tracing-subscriber = { version = "0.3.20", features = [
 url = { version = "2.5.8", features = ["serde"] }
 uuid = { version = "1.23.4" }
 
-hopr-bindings = "4.9.1"
-hopr-types = { version = "1.11.1", features = [
+hopr-bindings = "4.10.0"
+hopr-types = { version = "2.0.0", features = [
   "chain",
   "crypto",
   "internal",

--- a/flake.lock
+++ b/flake.lock
@@ -197,16 +197,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778977639,
-        "narHash": "sha256-bME6zzixM9IO1QbB6da0rSRXI8/mlhp87RmD1IstXMc=",
+        "lastModified": 1784011430,
+        "narHash": "sha256-lDebytrYdd47IBLwvNOD+6AGeoqZ78CIKlp70hzW280=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bb7f1f470ee929b87856f4640712e2eb5cddb405",
+        "rev": "8eeec934ae0dbeca3d7868c059568a65c08b2fc3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     # Core Nix ecosystem dependencies
     flake-utils.url = "github:numtide/flake-utils";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    nixpkgs.url = "github:NixOS/nixpkgs/release-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-26.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # HOPR Nix Library (provides flake-utils and reusable build functions)

--- a/src/environment_config.rs
+++ b/src/environment_config.rs
@@ -224,9 +224,10 @@ mod tests {
         // create client
         let client = create_rpc_client_to_anvil(&anvil, &contract_deployer);
         // deploy local contracts
-        let instances = ContractInstances::deploy_for_testing(client.clone(), a2h(contract_deployer_address))
-            .await
-            .expect("failed to deploy");
+        let instances =
+            ContractInstances::deploy_for_testing(client.clone(), a2h(contract_deployer_address), anvil.addresses()[1])
+                .await
+                .expect("failed to deploy");
 
         // temporary write the contract addresses to a json file
         let temp_dir = tempfile::tempdir().expect("failed to create temp dir");

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -1341,12 +1341,17 @@ pub fn create_rpc_client_to_anvil(
     signer: &hopr_types::crypto::keypairs::ChainKeypair,
 ) -> Arc<AnvilRpcClient> {
     use hopr_bindings::exports::alloy::{
-        providers::ProviderBuilder, rpc::client::ClientBuilder, signers::local::PrivateKeySigner,
-        transports::http::ReqwestTransport,
+        network::EthereumWallet, providers::ProviderBuilder, rpc::client::ClientBuilder,
+        signers::local::PrivateKeySigner, transports::http::ReqwestTransport,
     };
     use hopr_types::crypto::keypairs::Keypair;
 
-    let wallet = PrivateKeySigner::from_slice(signer.secret().as_ref()).expect("failed to construct wallet");
+    let common_deployer = PrivateKeySigner::from_slice(anvil.keys()[1].to_bytes().as_ref())
+        .expect("failed to construct common deployer wallet");
+    let contract_deployer =
+        PrivateKeySigner::from_slice(signer.secret().as_ref()).expect("failed to construct contract deployer wallet");
+    let mut wallet = EthereumWallet::from(common_deployer);
+    wallet.register_default_signer(contract_deployer);
 
     let transport_client = ReqwestTransport::new(anvil.endpoint_url());
 
@@ -1413,12 +1418,15 @@ mod tests {
         let contract_deployer = ChainKeypair::from_secret(anvil.keys()[0].to_bytes().as_ref())?;
         let client = create_rpc_client_to_anvil(&anvil, &contract_deployer);
         // deploy hopr contracts
-        let instances =
-            ContractInstances::deploy_for_testing(client.clone(), a2h(contract_deployer.public().to_address()))
-                .await
-                .expect("failed to deploy");
+        let instances = ContractInstances::deploy_for_testing(
+            client.clone(),
+            a2h(contract_deployer.public().to_address()),
+            anvil.addresses()[1],
+        )
+        .await
+        .expect("failed to deploy");
         // deploy multicall contract
-        ContractInstances::deploy_multicall3(client.clone()).await?;
+        ContractInstances::deploy_multicall3(client.clone(), anvil.addresses()[1]).await?;
 
         // get native and token balances
         let (native_balance, token_balance) = get_native_and_token_balances(instances.token, vec![kp_address]).await?;
@@ -1445,14 +1453,17 @@ mod tests {
         let contract_deployer = ChainKeypair::from_secret(anvil.keys()[0].to_bytes().as_ref())?;
         let client = create_rpc_client_to_anvil(&anvil, &contract_deployer);
         // deploy hopr contracts
-        let instances =
-            ContractInstances::deploy_for_testing(client.clone(), a2h(contract_deployer.public().to_address()))
-                .await
-                .expect("failed to deploy");
+        let instances = ContractInstances::deploy_for_testing(
+            client.clone(),
+            a2h(contract_deployer.public().to_address()),
+            anvil.addresses()[1],
+        )
+        .await
+        .expect("failed to deploy");
         println!("deployed hopr contracts {:?}", instances);
 
         // deploy multicall contract
-        ContractInstances::deploy_multicall3(client.clone()).await?;
+        ContractInstances::deploy_multicall3(client.clone(), anvil.addresses()[1]).await?;
         // grant deployer token minter role
         let encoded_minter_role = keccak256(b"MINTER_ROLE");
         instances
@@ -1502,13 +1513,16 @@ mod tests {
         let contract_deployer = ChainKeypair::from_secret(anvil.keys()[0].to_bytes().as_ref())?;
         let client = create_rpc_client_to_anvil(&anvil, &contract_deployer);
         // deploy hopr contracts
-        let instances =
-            ContractInstances::deploy_for_testing(client.clone(), a2h(contract_deployer.public().to_address()))
-                .await
-                .expect("failed to deploy");
+        let instances = ContractInstances::deploy_for_testing(
+            client.clone(),
+            a2h(contract_deployer.public().to_address()),
+            anvil.addresses()[1],
+        )
+        .await
+        .expect("failed to deploy");
 
         // deploy multicall contract
-        ContractInstances::deploy_multicall3(client.clone()).await?;
+        ContractInstances::deploy_multicall3(client.clone(), anvil.addresses()[1]).await?;
         // grant deployer token minter role
         let encoded_minter_role = keccak256(b"MINTER_ROLE");
         instances
@@ -1556,13 +1570,16 @@ mod tests {
         let contract_deployer = ChainKeypair::from_secret(anvil.keys()[0].to_bytes().as_ref())?;
         let client = create_rpc_client_to_anvil(&anvil, &contract_deployer);
         // deploy hopr contracts
-        let instances =
-            ContractInstances::deploy_for_testing(client.clone(), a2h(contract_deployer.public().to_address()))
-                .await
-                .expect("failed to deploy");
+        let instances = ContractInstances::deploy_for_testing(
+            client.clone(),
+            a2h(contract_deployer.public().to_address()),
+            anvil.addresses()[1],
+        )
+        .await
+        .expect("failed to deploy");
 
         // deploy multicall contract
-        ContractInstances::deploy_multicall3(client.clone()).await?;
+        ContractInstances::deploy_multicall3(client.clone(), anvil.addresses()[1]).await?;
 
         // transfer or mint tokens to addresses
         let total_transferred_amount =
@@ -1596,13 +1613,16 @@ mod tests {
         let anvil = create_anvil(None);
         let contract_deployer = ChainKeypair::from_secret(anvil.keys()[0].to_bytes().as_ref())?;
         let client = create_rpc_client_to_anvil(&anvil, &contract_deployer);
-        let instances =
-            ContractInstances::deploy_for_testing(client.clone(), a2h(contract_deployer.public().to_address()))
-                .await
-                .expect("failed to deploy");
+        let instances = ContractInstances::deploy_for_testing(
+            client.clone(),
+            a2h(contract_deployer.public().to_address()),
+            anvil.addresses()[1],
+        )
+        .await
+        .expect("failed to deploy");
 
         // deploy multicall contract
-        ContractInstances::deploy_multicall3(client.clone()).await?;
+        ContractInstances::deploy_multicall3(client.clone(), anvil.addresses()[1]).await?;
 
         // transfer native tokens to addresses
         let total_transferred_amount =
@@ -1670,14 +1690,17 @@ mod tests {
         let anvil = create_anvil(None);
         let contract_deployer = ChainKeypair::from_secret(anvil.keys()[0].to_bytes().as_ref())?;
         let client = create_rpc_client_to_anvil(&anvil, &contract_deployer);
-        let instances =
-            ContractInstances::deploy_for_testing(client.clone(), a2h(contract_deployer.public().to_address()))
-                .await
-                .expect("failed to deploy");
+        let instances = ContractInstances::deploy_for_testing(
+            client.clone(),
+            a2h(contract_deployer.public().to_address()),
+            anvil.addresses()[1],
+        )
+        .await
+        .expect("failed to deploy");
         // deploy multicall contract
-        ContractInstances::deploy_multicall3(client.clone()).await?;
+        ContractInstances::deploy_multicall3(client.clone(), anvil.addresses()[1]).await?;
         // deploy safe suits
-        ContractInstances::deploy_safe_suites(client.clone()).await?;
+        ContractInstances::deploy_safe_suites(client.clone(), anvil.addresses()[1]).await?;
 
         let caller = client.default_signer_address();
 
@@ -1775,14 +1798,17 @@ mod tests {
         let anvil = create_anvil(None);
         let contract_deployer = ChainKeypair::from_secret(anvil.keys()[0].to_bytes().as_ref())?;
         let client = create_rpc_client_to_anvil(&anvil, &contract_deployer);
-        let instances =
-            ContractInstances::deploy_for_testing(client.clone(), a2h(contract_deployer.public().to_address()))
-                .await
-                .expect("failed to deploy");
+        let instances = ContractInstances::deploy_for_testing(
+            client.clone(),
+            a2h(contract_deployer.public().to_address()),
+            anvil.addresses()[1],
+        )
+        .await
+        .expect("failed to deploy");
         // deploy multicall contract
-        ContractInstances::deploy_multicall3(client.clone()).await?;
+        ContractInstances::deploy_multicall3(client.clone(), anvil.addresses()[1]).await?;
         // deploy safe suits
-        ContractInstances::deploy_safe_suites(client.clone()).await?;
+        ContractInstances::deploy_safe_suites(client.clone(), anvil.addresses()[1]).await?;
 
         // grant deployer token minter role
         let encoded_minter_role = keccak256(b"MINTER_ROLE");
@@ -1872,16 +1898,19 @@ mod tests {
         let anvil = create_anvil(None);
         let contract_deployer = ChainKeypair::from_secret(anvil.keys()[0].to_bytes().as_ref())?;
         let client = create_rpc_client_to_anvil(&anvil, &contract_deployer);
-        let instances =
-            ContractInstances::deploy_for_testing(client.clone(), a2h(contract_deployer.public().to_address()))
-                .await
-                .expect("failed to deploy");
+        let instances = ContractInstances::deploy_for_testing(
+            client.clone(),
+            a2h(contract_deployer.public().to_address()),
+            anvil.addresses()[1],
+        )
+        .await
+        .expect("failed to deploy");
 
         println!("deployed hopr contracts {:?}", instances);
         // deploy multicall contract
-        ContractInstances::deploy_multicall3(client.clone()).await?;
+        ContractInstances::deploy_multicall3(client.clone(), anvil.addresses()[1]).await?;
         // deploy safe suits
-        ContractInstances::deploy_safe_suites(client.clone()).await?;
+        ContractInstances::deploy_safe_suites(client.clone(), anvil.addresses()[1]).await?;
 
         // register some nodes
         let (safe, node_module) = deploy_safe_module_with_targets_and_nodes(
@@ -1944,14 +1973,17 @@ mod tests {
         let anvil = create_anvil(None);
         let contract_deployer = ChainKeypair::from_secret(anvil.keys()[0].to_bytes().as_ref())?;
         let client = create_rpc_client_to_anvil(&anvil, &contract_deployer);
-        let instances =
-            ContractInstances::deploy_for_testing(client.clone(), a2h(contract_deployer.public().to_address()))
-                .await
-                .expect("failed to deploy");
+        let instances = ContractInstances::deploy_for_testing(
+            client.clone(),
+            a2h(contract_deployer.public().to_address()),
+            anvil.addresses()[1],
+        )
+        .await
+        .expect("failed to deploy");
         // deploy multicall contract
-        ContractInstances::deploy_multicall3(client.clone()).await?;
+        ContractInstances::deploy_multicall3(client.clone(), anvil.addresses()[1]).await?;
         // deploy safe suits
-        ContractInstances::deploy_safe_suites(client.clone()).await?;
+        ContractInstances::deploy_safe_suites(client.clone(), anvil.addresses()[1]).await?;
 
         // create a safe
         let (safe, _node_module) = deploy_safe_module_with_targets_and_nodes(
@@ -2039,14 +2071,17 @@ mod tests {
         let anvil = create_anvil(None);
         let contract_deployer = ChainKeypair::from_secret(anvil.keys()[0].to_bytes().as_ref())?;
         let client = create_rpc_client_to_anvil(&anvil, &contract_deployer);
-        let instances =
-            ContractInstances::deploy_for_testing(client.clone(), a2h(contract_deployer.public().to_address()))
-                .await
-                .expect("failed to deploy");
+        let instances = ContractInstances::deploy_for_testing(
+            client.clone(),
+            a2h(contract_deployer.public().to_address()),
+            anvil.addresses()[1],
+        )
+        .await
+        .expect("failed to deploy");
         // deploy multicall contract
-        ContractInstances::deploy_multicall3(client.clone()).await?;
+        ContractInstances::deploy_multicall3(client.clone(), anvil.addresses()[1]).await?;
         // deploy safe suits
-        ContractInstances::deploy_safe_suites(client.clone()).await?;
+        ContractInstances::deploy_safe_suites(client.clone(), anvil.addresses()[1]).await?;
 
         let deployer_vec: Vec<Address> = vec![a2h(contract_deployer.public().to_address())];
 
@@ -2117,14 +2152,17 @@ mod tests {
         let anvil = create_anvil(None);
         let contract_deployer = ChainKeypair::from_secret(anvil.keys()[0].to_bytes().as_ref())?;
         let client = create_rpc_client_to_anvil(&anvil, &contract_deployer);
-        let instances =
-            ContractInstances::deploy_for_testing(client.clone(), a2h(contract_deployer.public().to_address()))
-                .await
-                .expect("failed to deploy");
+        let instances = ContractInstances::deploy_for_testing(
+            client.clone(),
+            a2h(contract_deployer.public().to_address()),
+            anvil.addresses()[1],
+        )
+        .await
+        .expect("failed to deploy");
         // deploy multicall contract
-        ContractInstances::deploy_multicall3(client.clone()).await?;
+        ContractInstances::deploy_multicall3(client.clone(), anvil.addresses()[1]).await?;
         // deploy safe suits
-        ContractInstances::deploy_safe_suites(client.clone()).await?;
+        ContractInstances::deploy_safe_suites(client.clone(), anvil.addresses()[1]).await?;
 
         let deployer_vec: Vec<Address> = vec![a2h(contract_deployer.public().to_address())];
 
@@ -2173,13 +2211,13 @@ mod tests {
         let contract_deployer = ChainKeypair::from_secret(anvil.keys()[0].to_bytes().as_ref())?;
         let self_address: Address = a2h(contract_deployer.public().to_address());
         let client = create_rpc_client_to_anvil(&anvil, &contract_deployer);
-        let instances = ContractInstances::deploy_for_testing(client.clone(), self_address)
+        let instances = ContractInstances::deploy_for_testing(client.clone(), self_address, anvil.addresses()[1])
             .await
             .expect("failed to deploy");
         // deploy multicall contract
-        ContractInstances::deploy_multicall3(client.clone()).await?;
+        ContractInstances::deploy_multicall3(client.clone(), anvil.addresses()[1]).await?;
         // deploy safe suits
-        ContractInstances::deploy_safe_suites(client.clone()).await?;
+        ContractInstances::deploy_safe_suites(client.clone(), anvil.addresses()[1]).await?;
 
         // deploy some new contracts for the new network
         let new_safe_registry = HoprNodeSafeRegistry::deploy(client.clone()).await?;
@@ -2245,14 +2283,17 @@ mod tests {
         let anvil = create_anvil(None);
         let contract_deployer = ChainKeypair::from_secret(anvil.keys()[0].to_bytes().as_ref())?;
         let client = create_rpc_client_to_anvil(&anvil, &contract_deployer);
-        let instances =
-            ContractInstances::deploy_for_testing(client.clone(), a2h(contract_deployer.public().to_address()))
-                .await
-                .expect("failed to deploy");
+        let instances = ContractInstances::deploy_for_testing(
+            client.clone(),
+            a2h(contract_deployer.public().to_address()),
+            anvil.addresses()[1],
+        )
+        .await
+        .expect("failed to deploy");
         // deploy multicall contract
-        ContractInstances::deploy_multicall3(client.clone()).await?;
+        ContractInstances::deploy_multicall3(client.clone(), anvil.addresses()[1]).await?;
         // deploy safe suits
-        ContractInstances::deploy_safe_suites(client.clone()).await?;
+        ContractInstances::deploy_safe_suites(client.clone(), anvil.addresses()[1]).await?;
 
         let deployer_vec: Vec<Address> = vec![a2h(contract_deployer.public().to_address())];
 


### PR DESCRIPTION
Also:

- bump hopr-bindings to v4.10.0
- bump nixpkgs to 26.05

This is needed to unblock the update in edge-client which uses hopli for testing.