### PR TITLE
fix(nix): add Dependabot for nix flake.lock updates, disable Renovate nix manager

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
       day: "monday"
       time: "02:00"
       timezone: "UTC"
+    cooldown:
+      default: 7
     groups:
       nix-flake-inputs:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Renovate's nix manager cannot update flake.lock on Mend-hosted infrastructure:
+  # it requires running `nix flake update` (to compute narHash values), but the
+  # sandboxed jr-microvm environment has no nix binary and allowedCommands is locked
+  # to git add/reset/pwd only. Every Monday run ends with "Digest is not updated" →
+  # level-40 "Error updating branch: update failure". Dependabot handles flake.lock
+  # instead; the nix manager is disabled in renovate.json.
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "02:00"
+      timezone: "UTC"
+    groups:
+      nix-flake-inputs:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       time: "02:00"
       timezone: "UTC"
     cooldown:
-      default: 7
+      default-days: 7
     groups:
       nix-flake-inputs:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   # Renovate's nix manager cannot update flake.lock on Mend-hosted infrastructure:

--- a/flake.nix
+++ b/flake.nix
@@ -218,6 +218,14 @@
                 language = "system";
                 pass_filenames = false;
               };
+              dependabot-validator = {
+                enable = true;
+                name = "Dependabot config validator";
+                entry = "${pkgs.check-jsonschema}/bin/check-jsonschema --builtin-schema vendor.dependabot";
+                files = "\\.github/dependabot\\.yml$";
+                language = "system";
+                pass_filenames = true;
+              };
             };
             tools = pkgs;
             excludes = [ ".gcloudignore" ];

--- a/renovate.json
+++ b/renovate.json
@@ -11,54 +11,66 @@
   "semanticCommits": "enabled",
   "rangeStrategy": "bump",
   "pinDigests": true,
-  "nix": { "enabled": true },
+  "nix": {
+    "enabled": false
+  },
   "vulnerabilityAlerts": {
     "enabled": true,
-    "labels": ["security"],
-    "schedule": ["at any time"],
+    "labels": [
+      "security"
+    ],
+    "schedule": [
+      "at any time"
+    ],
     "automerge": true
   },
   "packageRules": [
     {
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "groupName": "github-actions",
       "pinDigests": true,
       "commitMessageTopic": "GitHub Actions"
     },
     {
-      "matchManagers": ["nix"],
-      "groupName": "nix flake updates",
-      "commitMessageTopic": "Nix flake inputs"
-    },
-    {
-      "description": "Expedite nix security updates — bypass weekly schedule",
-      "matchManagers": ["nix"],
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
-      "schedule": ["at any time"],
-      "automerge": true,
-      "labels": ["security"],
-      "groupName": "nix security updates",
-      "commitMessageTopic": "Nix security updates"
-    },
-    {
-      "matchManagers": ["cargo"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
       "groupName": "cargo dependencies",
       "commitMessageTopic": "Cargo dependencies"
     },
     {
-      "description": "Expedite cargo security updates — bypass weekly schedule",
-      "matchManagers": ["cargo"],
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
-      "schedule": ["at any time"],
+      "description": "Expedite cargo security updates \u2014 bypass weekly schedule",
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchJsonata": [
+        "$exists(vulnerabilityFixVersion)"
+      ],
+      "schedule": [
+        "at any time"
+      ],
       "automerge": true,
-      "labels": ["security"],
+      "labels": [
+        "security"
+      ],
       "groupName": "cargo security updates",
       "commitMessageTopic": "Cargo security updates"
     },
     {
-      "matchManagers": ["cargo"],
-      "matchPackageNames": ["serde_yaml", "libp2p-stream", "rand"],
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchPackageNames": [
+        "serde_yaml",
+        "libp2p-stream",
+        "rand"
+      ],
       "enabled": false
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -16,61 +16,36 @@
   },
   "vulnerabilityAlerts": {
     "enabled": true,
-    "labels": [
-      "security"
-    ],
-    "schedule": [
-      "at any time"
-    ],
+    "labels": ["security"],
+    "schedule": ["at any time"],
     "automerge": true
   },
   "packageRules": [
     {
-      "matchManagers": [
-        "github-actions"
-      ],
+      "matchManagers": ["github-actions"],
       "groupName": "github-actions",
       "pinDigests": true,
       "commitMessageTopic": "GitHub Actions"
     },
     {
-      "matchManagers": [
-        "cargo"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["minor", "patch"],
       "groupName": "cargo dependencies",
       "commitMessageTopic": "Cargo dependencies"
     },
     {
       "description": "Expedite cargo security updates \u2014 bypass weekly schedule",
-      "matchManagers": [
-        "cargo"
-      ],
-      "matchJsonata": [
-        "$exists(vulnerabilityFixVersion)"
-      ],
-      "schedule": [
-        "at any time"
-      ],
+      "matchManagers": ["cargo"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "schedule": ["at any time"],
       "automerge": true,
-      "labels": [
-        "security"
-      ],
+      "labels": ["security"],
       "groupName": "cargo security updates",
       "commitMessageTopic": "Cargo security updates"
     },
     {
-      "matchManagers": [
-        "cargo"
-      ],
-      "matchPackageNames": [
-        "serde_yaml",
-        "libp2p-stream",
-        "rand"
-      ],
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["serde_yaml", "libp2p-stream", "rand"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
Renovate's `nix` manager cannot update `flake.lock` on Mend-hosted infrastructure — the sandboxed runner has no `nix` binary and `allowedCommands` is restricted to `git add/reset/pwd`, causing a level-40 "Digest is not updated" error every Monday. Switches to Dependabot's native nix ecosystem support (2026-04-07), which monitors `flake.lock` weekly and groups all inputs into a single PR via `nix-flake-inputs`; disables the Renovate nix manager; adds a `dependabot-validator` pre-commit hook (`check-jsonschema` ≥ 0.37.2 from nixpkgs 26.05); and sets a 7-day cooldown to satisfy the zizmor `insufficient-cooldown` audit.