### PR TITLE
feat: add service registry operator commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2722,6 +2722,7 @@ dependencies = [
 [[package]]
 name = "hopr-bindings"
 version = "4.12.2"
+source = "git+https://github.com/hoprnet/contracts?rev=6ce45eb5e7d433545d82ea32e27562eb0fc329c3#6ce45eb5e7d433545d82ea32e27562eb0fc329c3"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2738,6 +2739,7 @@ dependencies = [
 [[package]]
 name = "hopr-types"
 version = "2.3.0"
+source = "git+https://github.com/hoprnet/hopr-types?rev=2a3bb391f1f98475d033b105c69090d050aaff0c#2a3bb391f1f98475d033b105c69090d050aaff0c"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,8 +2778,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "2.3.0"
-source = "git+https://github.com/hoprnet/hopr-types?rev=68d626ba041da06fde90c9c3c51a4d53c5ab0c4c#68d626ba041da06fde90c9c3c51a4d53c5ab0c4c"
+version = "2.4.0"
+source = "git+https://github.com/hoprnet/hopr-types?rev=47f3f1b80d9aa3fbb4d6adc73d7fde3dbd84e3cb#47f3f1b80d9aa3fbb4d6adc73d7fde3dbd84e3cb"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,7 +2762,7 @@ dependencies = [
 [[package]]
 name = "hopr-bindings"
 version = "4.14.0"
-source = "git+https://github.com/hoprnet/contracts?rev=0eea1981c67343e65ff4e5ecb0b81b9ddc201b14#0eea1981c67343e65ff4e5ecb0b81b9ddc201b14"
+source = "git+https://github.com/hoprnet/contracts?rev=ee2ab3ab6524a764de0c58543ba2c68d1f75ad9c#ee2ab3ab6524a764de0c58543ba2c68d1f75ad9c"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2779,7 +2779,7 @@ dependencies = [
 [[package]]
 name = "hopr-types"
 version = "2.4.0"
-source = "git+https://github.com/hoprnet/hopr-types?rev=47f3f1b80d9aa3fbb4d6adc73d7fde3dbd84e3cb#47f3f1b80d9aa3fbb4d6adc73d7fde3dbd84e3cb"
+source = "git+https://github.com/hoprnet/hopr-types?rev=fbbb743010a858bc2fa8c79e6140b8aa0c09a19a#fbbb743010a858bc2fa8c79e6140b8aa0c09a19a"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9677ab3454c237abe6307805bea17a7912b3a516b606c7b4d3d948b9fede137"
+checksum = "9867f85f660948ddbef071ae484027654c04b62c7decd5b61464a7ed1f8931a0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0f42ee16e9eaffa4df5aa3a17b1df88dd222310d13152ab91357a2551fd054"
+checksum = "12a542fe1e6a48cfd010a9e8eba1235436de58ee0f1415e588c27d5d556e98df"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db388e804269d977d60fa7530ccfefe9184ca48d4055dad3ec7e649a29186a06"
+checksum = "05ac1559726a5e71d6dbab59cbd8ad0988c762105d2ae41ae4f3241a3166262d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69937abc65310c6eb739e540b107688943b61f38e7dcf9fde769367d3608d657"
+checksum = "b86722084d6d07822a6c67e39ae794d437fb9de12fa4127d4f9fd93f89651121"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -138,7 +138,9 @@ dependencies = [
  "futures-util",
  "serde_json",
  "thiserror",
+ "tokio",
  "tracing",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -225,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52010e7c255f45b0ef3ca18144cbfbe0c044b055fe53f59323f3df5d95f265b1"
+checksum = "d40246adf7468b430fce87945ece8a54ef27fa760dd9f670f5162a412007bdb2"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -248,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-ens"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c3d803649b2023413a5b84892ed3874977dfa8b8d5481dea05488f20f6f4ef"
+checksum = "be9aa797694e7c55b007aa8f172daef76a83272cbedb8800bdc7038eed3bdb1a"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -262,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60fa6337a6af8bae818de3030448827bf55c1321c90c7d1f6f3b79257ead2a"
+checksum = "4951473e6ff25cdf82eb87b6a1a5fbb4af9c97528398a4a62fbf516198ec5028"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -302,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d7ff4d7f1503d12edda9b241904a309d6e1d5bcee3f0ffdc4d3d3f16f366b8"
+checksum = "7e5722ea29a9a85ecdba2516c58f50d71e77cd25f8ce7e9f4ee8570ddeee6df1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -317,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ff1439d901b44f6ff840545f82d65e66830ee33fb33cae495a566d66e0ccc8"
+checksum = "e2e4d278913f00ab611f5367448a3a800fed173ab791c3cc67b7a1b0d7afd305"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -343,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb920286c4a71fb0ff3bbb207a640a531a42fceef5b43d4a943f7d5265789876"
+checksum = "e4e52ae56d1acaa6b46e9d7015b8ae6c10f3d1c213a32ae70b17426a03ae6729"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -356,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2d06c4044c3ae7f9b7a70c9a7bb3bde9a08e99f4d9aa91001e17a182b562dc"
+checksum = "cdbb4a1bc03b411a3880d410ccc48d866b72d753ab1080605631890955b9caa2"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -406,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329375f50202cc6b2dcc8c6b1e53b716cbbebbeea54e931befc4f3b628dfc469"
+checksum = "386124639a5c386329b9f2ef2b42969badbf7bba40422b513e3e5739c516dc34"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -469,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bffef2c5714f578f267bb959b47908b95728f1f3e2073a96d928f4441c148d"
+checksum = "3dfd3ebc1756426a6a9e17979d4467632aff01f359136c50e5320ac6e32d6b8d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -492,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64449cae1cf37c4907b10ccca1613b71809f9a1f3ad6e2b4cc14d08e2e4947f"
+checksum = "417dc664965e36fc43a4f9c8eb8b2d14067a29c430e23470d2c923c1c977bac7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -504,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261411a259d346a69078237e2997a7ce0faba006baf5b1937023316d5ef07bf4"
+checksum = "5a07bb602ee07767e393b5862f719a1d061deca15e617fbb1f7af49cd49576e4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -516,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe7fa70c3af4b2de7f670b50d680700e0f979ce3a0ab7725958b51ffc3b16c2"
+checksum = "cd0a6cce3f97e5d9c0048081b5d173e0e406c2056c52c012e578a1d451ff0cdc"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -531,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f60a196df184facc9acbb61bd765a36cfb3c9d27eb6b43d5bd26340df1b96a"
+checksum = "1eb4c87dfdde83cd97e03a8c0c5e986b52e14075e02266e322ac6c7eb02e7399"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -552,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07758cbde42596b66da52bb661d77e253c3f7f9b3f553faf07adbadeb6419502"
+checksum = "2ff89f75b8a9d00f659750e9220c31b42d67c69ffc43b2ac8911dfd0506eb4a6"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -563,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc43a73bc1bf7044898e1b0dcefaba45d0cfac3e379bb5ca29cc3e3a04c61451"
+checksum = "69e1f6fae3ade809daa4c32bee35a30a439bb307209d7b42f3995988b5cc74b8"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -578,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372ff9be2b61c2cd6d33cfcef9bd5865962c0628c932767f5154443aba2c9746"
+checksum = "621cc39c34b85875858ef149598f3d5f9797dff9a3247f3606fcc06f9b20acc8"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -667,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830c87b05870c80c8d2cfb9245feaff36468893f19fc124c7ff563cabda6386c"
+checksum = "06f4ca8484d6295d5165f67de8fdb00ae630ba585efb606f003171286b56441c"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -690,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ecd298fb0e6a31bd90c72efba2728e3d7569f1c89a3719576fb0e4e40b0fc8"
+checksum = "8342aa5a7f8dee6d606307eebbc847d9799a823c7e4f37b9c1e32b08715f73c8"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -725,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50185b84799c8b5f016a0c9da74309fe28d1c70fbe590a4e8d9cae6df3eebb0"
+checksum = "1d0626c4f3b2028f7e8db32f53c22d9ecd5939f772317b7c4b6fe5219cb0589a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -820,9 +822,20 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -833,13 +846,34 @@ checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash",
  "ark-ff 0.5.0",
- "ark-poly",
+ "ark-poly 0.5.0",
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.0",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1025,6 +1059,21 @@ dependencies = [
  "educe",
  "fnv",
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -1232,7 +1281,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e657c11493f07dd18f0c6055b58e77ca71e30ed34f2804468b22f89e36dc0a"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "elliptic-curve 0.14.1",
@@ -2265,7 +2314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2603,21 +2652,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -2721,8 +2761,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.12.2"
-source = "git+https://github.com/hoprnet/contracts?rev=6ce45eb5e7d433545d82ea32e27562eb0fc329c3#6ce45eb5e7d433545d82ea32e27562eb0fc329c3"
+version = "4.14.0"
+source = "git+https://github.com/hoprnet/contracts?rev=0eea1981c67343e65ff4e5ecb0b81b9ddc201b14#0eea1981c67343e65ff4e5ecb0b81b9ddc201b14"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2739,11 +2779,15 @@ dependencies = [
 [[package]]
 name = "hopr-types"
 version = "2.3.0"
-source = "git+https://github.com/hoprnet/hopr-types?rev=2a3bb391f1f98475d033b105c69090d050aaff0c#2a3bb391f1f98475d033b105c69090d050aaff0c"
+source = "git+https://github.com/hoprnet/hopr-types?rev=68d626ba041da06fde90c9c3c51a4d53c5ab0c4c#68d626ba041da06fde90c9c3c51a4d53c5ab0c4c"
 dependencies = [
  "aes",
  "anyhow",
  "aquamarine",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "arrayvec",
  "async-trait",
  "babyjubjub-ec",
@@ -3416,11 +3460,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -3532,7 +3576,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4064,7 +4108,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4456,7 +4500,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4513,7 +4557,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5162,8 +5206,8 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55b5a2cc31c90e79778c4f6375e5d9828171d320db3f8c911a8ad47af4a70069"
 dependencies = [
- "ark-bn254",
- "ark-ec",
+ "ark-bn254 0.5.0",
+ "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-std 0.5.0",
 ]
@@ -5184,7 +5228,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5842,7 +5886,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5910,7 +5954,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5919,16 +5963,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5946,31 +5981,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -5980,22 +5998,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6004,22 +6010,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6028,22 +6022,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6052,22 +6034,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher",
  "cpubits",
@@ -780,7 +780,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -791,14 +791,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "aquamarine"
@@ -1172,13 +1172,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2265,7 +2265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "hopli"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "alloy-transport-http",
  "anyhow",
@@ -2721,9 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0375fb0dc90a31484ae7620ce71681203f5ed1ee670cab51e02fb3b7a9d351dc"
+version = "4.12.2"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2739,9 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aabecd53d5211c4a81f046d27bad0f7ad64659afcb5b88e0e410ecaa8928bf3"
+version = "2.3.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -2835,9 +2831,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "serde",
  "subtle",
@@ -3534,7 +3530,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4244,9 +4240,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4256,9 +4252,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4458,7 +4454,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4515,7 +4511,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4745,9 +4741,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4765,29 +4761,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -4985,7 +4981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5116,6 +5112,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn-solidity"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5175,27 +5182,27 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5621,9 +5628,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5833,7 +5840,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ tracing-subscriber = { version = "0.3.20", features = [
 url = { version = "2.5.8", features = ["serde"] }
 uuid = { version = "1.23.4" }
 
-hopr-bindings = "4.12.2"
-hopr-types = { version = "2.3.0", features = [
+hopr-bindings = { git = "https://github.com/hoprnet/contracts", rev = "6ce45eb5e7d433545d82ea32e27562eb0fc329c3" }
+hopr-types = { git = "https://github.com/hoprnet/hopr-types", rev = "2a3bb391f1f98475d033b105c69090d050aaff0c", features = [
   "chain",
   "crypto",
   "internal",
@@ -105,14 +105,3 @@ strip           = false
 
 [package.metadata.cargo-machete]
 ignored = ["alloy-transport-http"]
-
-# TODO: revert to crates.io versions once contracts publishes hopr-bindings 4.12.2 and
-# hopr-types publishes 2.3.0. Mirrors the TODO in hopr-types/Cargo.toml.
-[patch.crates-io]
-hopr-bindings = { path = "../contracts/ethereum/bindings" }
-hopr-types = { path = "../hopr-types" }
-
-# hopr-types pins hopr-bindings to a contracts git rev, so patching crates.io alone leaves two
-# copies of the crate in the graph and their alloy types stop unifying.
-[patch."https://github.com/hoprnet/contracts"]
-hopr-bindings = { path = "../contracts/ethereum/bindings" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ allocator-mimalloc = [
 default = []
 
 [dependencies]
-alloy-transport-http = { version = "2.0.4", features = ["reqwest-default-tls"] }
+alloy-transport-http = { version = "2.4.1", features = ["reqwest-default-tls"] }
 anyhow = "1.0.103"
 clap = { version = "4.6.1", features = ["derive", "env", "string"] }
 hex = "0.4.3"
@@ -47,8 +47,8 @@ tracing-subscriber = { version = "0.3.20", features = [
 url = { version = "2.5.8", features = ["serde"] }
 uuid = { version = "1.23.4" }
 
-hopr-bindings = { git = "https://github.com/hoprnet/contracts", rev = "6ce45eb5e7d433545d82ea32e27562eb0fc329c3" }
-hopr-types = { git = "https://github.com/hoprnet/hopr-types", rev = "2a3bb391f1f98475d033b105c69090d050aaff0c", features = [
+hopr-bindings = { git = "https://github.com/hoprnet/contracts", rev = "0eea1981c67343e65ff4e5ecb0b81b9ddc201b14" }
+hopr-types = { git = "https://github.com/hoprnet/hopr-types", rev = "68d626ba041da06fde90c9c3c51a4d53c5ab0c4c", features = [
   "chain",
   "crypto",
   "internal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2024"
 license = "GPL-3.0-only"
 name    = "hopli"
-version = "0.18.0"
+version = "0.19.0"
 
 [lib]
 name = "hopli_lib"
@@ -47,8 +47,8 @@ tracing-subscriber = { version = "0.3.20", features = [
 url = { version = "2.5.8", features = ["serde"] }
 uuid = { version = "1.23.4" }
 
-hopr-bindings = "4.12.0"
-hopr-types = { version = "2.0.2", features = [
+hopr-bindings = "4.12.2"
+hopr-types = { version = "2.3.0", features = [
   "chain",
   "crypto",
   "internal",
@@ -105,3 +105,14 @@ strip           = false
 
 [package.metadata.cargo-machete]
 ignored = ["alloy-transport-http"]
+
+# TODO: revert to crates.io versions once contracts publishes hopr-bindings 4.12.2 and
+# hopr-types publishes 2.3.0. Mirrors the TODO in hopr-types/Cargo.toml.
+[patch.crates-io]
+hopr-bindings = { path = "../contracts/ethereum/bindings" }
+hopr-types = { path = "../hopr-types" }
+
+# hopr-types pins hopr-bindings to a contracts git rev, so patching crates.io alone leaves two
+# copies of the crate in the graph and their alloy types stop unifying.
+[patch."https://github.com/hoprnet/contracts"]
+hopr-bindings = { path = "../contracts/ethereum/bindings" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ tracing-subscriber = { version = "0.3.20", features = [
 url = { version = "2.5.8", features = ["serde"] }
 uuid = { version = "1.23.4" }
 
-hopr-bindings = { git = "https://github.com/hoprnet/contracts", rev = "0eea1981c67343e65ff4e5ecb0b81b9ddc201b14" }
-hopr-types = { git = "https://github.com/hoprnet/hopr-types", rev = "47f3f1b80d9aa3fbb4d6adc73d7fde3dbd84e3cb", features = [
+hopr-bindings = { git = "https://github.com/hoprnet/contracts", rev = "ee2ab3ab6524a764de0c58543ba2c68d1f75ad9c" }
+hopr-types = { git = "https://github.com/hoprnet/hopr-types", rev = "fbbb743010a858bc2fa8c79e6140b8aa0c09a19a", features = [
   "chain",
   "crypto",
   "internal",

--- a/README.md
+++ b/README.md
@@ -208,6 +208,20 @@ hopli safe-module add-node \
   --private-key <PRIVATE_KEY>
 ```
 
+Scope the current network's service registry on a module created before service-registry support:
+
+```bash
+hopli safe-module add-service-registry-target \
+  --network anvil-localhost \
+  --provider-url http://127.0.0.1:8545 \
+  --safe-address 0xSafe... \
+  --module-address 0xModule... \
+  --private-key <SAFE_OWNER_PRIVATE_KEY>
+```
+
+The operation is idempotent. New and replacement modules created by the current factory already
+scope the configured service registry automatically.
+
 Move nodes to a new safe/module pair:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - identity file creation and maintenance
 - node funding (native and HOPR tokens)
 - Safe + module setup and migration
+- service registry entries and service types
 - winning-probability contract operations
 
 ## Build
@@ -50,6 +51,12 @@ You can also set:
 export HOPLI_CONTRACTS_ROOT=/path/to/contracts
 ```
 
+The `contracts-addresses.json` schema now includes a `service_registry` address for every network.
+A `--contracts-root` or `HOPLI_CONTRACTS_ROOT` that points at a contracts checkout from before the
+service registry therefore fails to load, with a deserialization error naming the missing field.
+Point it at a current checkout, add the field (the zero address means "not deployed on this
+network"), or drop the flag and use the embedded configuration.
+
 ### Identity input
 
 Commands that operate on identities accept either:
@@ -82,6 +89,7 @@ Subcommands:
 - `hopli identity` (`id`)
 - `hopli faucet`
 - `hopli safe-module` (`sm`)
+- `hopli service` (`svc`)
 - `hopli win-prob` (`wp`)
 
 Use `--help` at any level for details, for example:
@@ -238,6 +246,101 @@ Convert from `f64` to contract encoding:
 ```bash
 hopli win-prob convert --winning-probability 0.5
 ```
+
+### 5. Service registry
+
+Entry writes go through the Safe bound to the node, because the registry only accepts that Safe as
+the sender. `--private-key` is therefore the key of a Safe **owner**, not of the node, and
+`--safe-address` is only needed when the binding cannot be read from the node-safe registry.
+Registering and updating cost the service type's burn in wxHOPR, which the Safe must hold; `hopli`
+puts an approval for exactly that burn in front of the call, in the same Safe transaction.
+
+Register a node under a service type:
+
+```bash
+hopli service register \
+  --network anvil-localhost \
+  --provider-url http://127.0.0.1:8545 \
+  --service-type gvpn:exit \
+  --node-address 0xNode... \
+  --metadata '{"endpoint":"https://exit.example"}' \
+  --private-key <SAFE_OWNER_PRIVATE_KEY>
+```
+
+Replace the metadata of an entry, reading it from a file (the only way to pass bytes that are not
+valid UTF-8):
+
+```bash
+hopli service update \
+  --network anvil-localhost \
+  --provider-url http://127.0.0.1:8545 \
+  --service-type gvpn:exit \
+  --node-address 0xNode... \
+  --metadata-file ./metadata.json \
+  --private-key <SAFE_OWNER_PRIVATE_KEY>
+```
+
+Remove an entry. This is free and never gated by the type's policy:
+
+```bash
+hopli service deregister \
+  --network anvil-localhost \
+  --provider-url http://127.0.0.1:8545 \
+  --service-type gvpn:exit \
+  --node-address 0xNode... \
+  --private-key <SAFE_OWNER_PRIVATE_KEY>
+```
+
+Read a single entry, list the entries of a type, or list the registered types. Both list commands
+read every page at one block, because the registry's list order changes as entries are removed:
+
+```bash
+hopli service get   --network anvil-localhost --provider-url http://127.0.0.1:8545 \
+  --service-type gvpn:exit --node-address 0xNode...
+hopli service list  --network anvil-localhost --provider-url http://127.0.0.1:8545 \
+  --service-type gvpn:exit
+hopli service types --network anvil-localhost --provider-url http://127.0.0.1:8545
+```
+
+Claim a service type. The caller pays the global registration fee and becomes the type owner:
+
+```bash
+hopli service register-type \
+  --network anvil-localhost \
+  --provider-url http://127.0.0.1:8545 \
+  --service-type gvpn:exit \
+  --registration-burn 1 \
+  --update-burn 0.5 \
+  --private-key <PRIVATE_KEY>
+```
+
+As the type owner, change the requirement contract or the burns:
+
+```bash
+hopli service set-requirement --service-type gvpn:exit --requirement 0xGate... ...
+hopli service set-registration-burn --service-type gvpn:exit --amount 2 ...
+hopli service set-update-burn --service-type gvpn:exit --amount 1 ...
+```
+
+Hand the type to another owner. Transfers are irreversible, so abandoning a type needs the
+explicit `--abandon` flag rather than a zero `--new-owner`:
+
+```bash
+hopli service transfer-type-ownership --service-type gvpn:exit --new-owner 0xNewOwner... ...
+hopli service transfer-type-ownership --service-type gvpn:exit --abandon ...
+```
+
+Manager and admin operations:
+
+```bash
+hopli service set-fee --amount 5 ...
+hopli service set-node-safe-registry --node-safe-registry 0xNew... \
+  --probe-node 0xNode... --expected-safe 0xSafe... ...
+hopli service recover-tokens --token 0xToken... --recipient 0xTo... ...
+```
+
+Commands fail with a "contract not deployed" error on networks where `service_registry` is the
+zero address.
 
 ## Development
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! - `identity`: create/read/update node identity files
 //! - `faucet`: distribute native/HOPR tokens to nodes
 //! - `safe_module`: create and operate Safe + module setups
+//! - `service`: read and write the on-chain registry of node services
 //! - `win_prob`: manage winning probability parameters
 
 pub mod environment_config;
@@ -14,6 +15,7 @@ pub mod key_pair;
 pub mod methods;
 pub mod payloads;
 pub mod safe_module;
+pub mod service;
 #[allow(clippy::too_many_arguments)]
 pub mod utils;
 pub mod win_prob;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use hopli_lib::{
     faucet::FaucetArgs,
     identity::IdentitySubcommands,
     safe_module::SafeModuleSubcommands,
+    service::ServiceSubcommands,
     utils::{Cmd, HelperErrors},
     win_prob::WinProbSubcommands,
 };
@@ -50,6 +51,13 @@ enum Commands {
         command: SafeModuleSubcommands,
     },
 
+    /// Read and write the on-chain registry of the services that HOPR nodes offer
+    #[command(visible_alias = "svc")]
+    Service {
+        #[command(subcommand)]
+        command: ServiceSubcommands,
+    },
+
     /// Commands around winning probability
     #[command(visible_alias = "wp")]
     WinProb {
@@ -82,6 +90,9 @@ async fn main() -> Result<(), HelperErrors> {
             opt.async_run().await?;
         }
         Commands::SafeModule { command } => {
+            command.async_run().await?;
+        }
+        Commands::Service { command } => {
             command.async_run().await?;
         }
         Commands::WinProb { command } => {

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -34,7 +34,7 @@ use hopr_bindings::{
     },
     hopr_node_management_module::HoprNodeManagementModule::{
         HoprNodeManagementModuleInstance, addChannelsAndTokenTargetCall, includeNodeCall, initializeCall,
-        removeNodeCall, scopeTargetTokenCall,
+        removeNodeCall, scopeTargetServiceRegistryCall, scopeTargetTokenCall,
     },
     hopr_node_safe_migration::HoprNodeSafeMigration::{
         deployNewV4ModuleCall, migrateSafeV141ToL2AndMigrateToUpgradeableModuleCall,
@@ -1205,6 +1205,62 @@ pub async fn add_new_network_target_to_module<P: WalletProvider + Provider>(
     .await?;
 
     Ok(())
+}
+
+/// Scope a service registry on an existing node-management module.
+///
+/// New modules receive the current registry from `HoprNodeStakeFactory` during initialization.
+/// This operation is for modules that predate that configuration. It is deliberately idempotent:
+/// the module rejects duplicate targets, so checking first lets operators safely rerun Hopli after
+/// an interrupted migration.
+pub async fn add_service_registry_target_to_module<P: WalletProvider + Provider>(
+    safe: SafeSingletonInstance<Arc<P>>,
+    module_address: Address,
+    service_registry_address: Address,
+    owner_chain_key: ChainKeypair,
+) -> Result<(), HelperErrors> {
+    if service_registry_address.is_zero() {
+        return Err(HelperErrors::ContractNotDeployed(
+            "HoprServiceRegistry address is zero".into(),
+        ));
+    }
+
+    let module = HoprNodeManagementModuleInstance::new(module_address, safe.provider().clone());
+    let current = module
+        .tryGetTarget(service_registry_address)
+        .call()
+        .await
+        .map_err(|e| {
+            HelperErrors::MiddlewareError(format!(
+                "cannot inspect the service-registry target; the module may need to be upgraded or replaced: {e}"
+            ))
+        })?;
+    if current._0 {
+        info!(%module_address, %service_registry_address, "service registry target is already scoped");
+        return Ok(());
+    }
+
+    let (chain_id, safe_nonce) = get_chain_id_and_safe_nonce(safe.clone()).await?;
+    let multisend_txns = vec![MultisendTransaction {
+        encoded_data: scopeTargetServiceRegistryCall {
+            serviceRegistry: service_registry_address,
+        }
+        .abi_encode()
+        .into(),
+        tx_operation: SafeTxOperation::Call,
+        to: module_address,
+        value: U256::ZERO,
+    }];
+
+    send_multisend_safe_transaction_with_threshold_one(
+        safe,
+        owner_chain_key,
+        SAFE_MULTISEND_ADDRESS,
+        multisend_txns,
+        chain_id,
+        safe_nonce,
+    )
+    .await
 }
 
 /// Quick check if the following values are correct, for one single node:
@@ -2504,6 +2560,35 @@ mod tests {
                 .any(|(addr, _)| addr == instances.channels.address()),
             "channels should be a scoped target"
         );
+        assert!(
+            hopr_module
+                .targets
+                .iter()
+                .any(|(addr, _)| addr == instances.service_registry.address()),
+            "new modules should automatically scope the configured service registry"
+        );
+
+        // Exercise the compatibility operation with an address that was not part of module
+        // initialization. This models adding a registry to an existing module. Calling it twice
+        // proves the preflight check makes retries idempotent.
+        let additional_registry = *instances.safe_registry.address();
+        assert!(
+            !node_module.tryGetTarget(additional_registry).call().await?._0,
+            "the compatibility target should start unscoped"
+        );
+        add_service_registry_target_to_module(
+            safe.clone(),
+            *node_module.address(),
+            additional_registry,
+            contract_deployer.clone(),
+        )
+        .await?;
+        assert!(
+            node_module.tryGetTarget(additional_registry).call().await?._0,
+            "the compatibility operation should scope the target"
+        );
+        add_service_registry_target_to_module(safe, *node_module.address(), additional_registry, contract_deployer)
+            .await?;
 
         Ok(())
     }

--- a/src/payloads.rs
+++ b/src/payloads.rs
@@ -8,7 +8,7 @@ use hopr_bindings::{
     },
     exports::alloy::{
         network::TransactionBuilder,
-        primitives::{Address, Bytes, U256, aliases::U56},
+        primitives::{Address, B256, Bytes, U256, aliases::U56},
         providers::{
             CallInfoTrait, MULTICALL3_ADDRESS,
             bindings::IMulticall3::{Call3, Call3Value, aggregate3Call, aggregate3ValueCall},
@@ -19,10 +19,15 @@ use hopr_bindings::{
     },
     hopr_node_management_module::HoprNodeManagementModule::includeNodeCall,
     hopr_node_stake_factory::HoprNodeStakeFactory::{cloneCall, predictModuleAddress_1Call},
-    hopr_token::HoprToken::{sendCall, transferCall},
+    hopr_service_registry::HoprServiceRegistry::{
+        recoverTokensCall, registerServiceTypeCall, selfDeregisterCall, selfRegisterCall, selfUpdateCall,
+        setNodeSafeRegistryCall, setRequirementCall, setSelfRegistrationBurnCall, setSelfUpdateBurnCall,
+        setTypeRegistrationFeeCall, transferTypeOwnershipCall,
+    },
+    hopr_token::HoprToken::{approveCall, sendCall, transferCall},
     hopr_winning_probability_oracle::HoprWinningProbabilityOracle::setWinProbCall,
 };
-use hopr_types::internal::prelude::WinningProbability;
+use hopr_types::internal::prelude::{ServiceMetadata, ServiceType, WinningProbability};
 use tracing::{debug, info};
 
 use crate::{
@@ -330,9 +335,429 @@ pub fn set_winning_probability(
     Ok(tx)
 }
 
+/// The `bytes32` service type id as the `HoprServiceRegistry` ABI expects it.
+fn service_type_id(service_type: &ServiceType) -> B256 {
+    B256::from(service_type.as_encoded())
+}
+
+/// Builds a request carrying `payload` to `contract_address`.
+fn call_payload(contract_address: Address, payload: Vec<u8>) -> TransactionRequest {
+    TransactionRequest::default()
+        .with_to(contract_address)
+        .with_input(payload)
+}
+
+/// Approve `spender` to pull exactly `amount` wxHOPR from the caller.
+///
+/// The service registry pulls its fees with `transferFrom`, so every paid registry call needs an
+/// allowance. The allowance is exact rather than unlimited on purpose: it is the caller's price
+/// protection. A fee raised between reading it and executing the call runs out of allowance and
+/// reverts, instead of silently overpaying (RFC section 3.6).
+pub fn approve_hopr_token_payload(token_address: Address, spender: Address, amount: U256) -> TransactionRequest {
+    call_payload(token_address, approveCall { spender, value: amount }.abi_encode())
+}
+
+/// Register `node` under `service_type` with `metadata`.
+///
+/// `msg.sender` must be the Safe bound to `node` in the node-safe registry, so this belongs in a
+/// Safe transaction, preceded by an [`approve_hopr_token_payload`] for the type's registration
+/// burn.
+pub fn self_register_service_payload(
+    service_registry_address: Address,
+    service_type: &ServiceType,
+    node: Address,
+    metadata: &ServiceMetadata,
+) -> TransactionRequest {
+    let payload = selfRegisterCall {
+        serviceType: service_type_id(service_type),
+        node,
+        metadata: Bytes::copy_from_slice(metadata.as_ref()),
+    }
+    .abi_encode();
+    call_payload(service_registry_address, payload)
+}
+
+/// Replace the metadata of the entry of `node` under `service_type`.
+///
+/// Same caller and allowance rules as [`self_register_service_payload`], against the type's
+/// update burn.
+pub fn self_update_service_payload(
+    service_registry_address: Address,
+    service_type: &ServiceType,
+    node: Address,
+    metadata: &ServiceMetadata,
+) -> TransactionRequest {
+    let payload = selfUpdateCall {
+        serviceType: service_type_id(service_type),
+        node,
+        metadata: Bytes::copy_from_slice(metadata.as_ref()),
+    }
+    .abi_encode();
+    call_payload(service_registry_address, payload)
+}
+
+/// Remove the entry of `node` under `service_type`.
+///
+/// Gated by the node-safe binding alone: it is free and takes no allowance, so that a bound node
+/// can always delist itself (invariant I6).
+pub fn self_deregister_service_payload(
+    service_registry_address: Address,
+    service_type: &ServiceType,
+    node: Address,
+) -> TransactionRequest {
+    let payload = selfDeregisterCall {
+        serviceType: service_type_id(service_type),
+        node,
+    }
+    .abi_encode();
+    call_payload(service_registry_address, payload)
+}
+
+/// Claim `service_type` and become its owner.
+///
+/// Callable by anyone, first come first served, and payable in the global type registration fee,
+/// so it needs an [`approve_hopr_token_payload`] for that fee.
+pub fn register_service_type_payload(
+    service_registry_address: Address,
+    service_type: &ServiceType,
+    requirement: Address,
+    registration_burn: U256,
+    update_burn: U256,
+) -> TransactionRequest {
+    let payload = registerServiceTypeCall {
+        serviceType: service_type_id(service_type),
+        requirement,
+        registrationBurn: registration_burn,
+        updateBurn: update_burn,
+    }
+    .abi_encode();
+    call_payload(service_registry_address, payload)
+}
+
+/// Point `service_type` at a new requirement contract, or open it up with the zero address.
+pub fn set_service_type_requirement_payload(
+    service_registry_address: Address,
+    service_type: &ServiceType,
+    requirement: Address,
+) -> TransactionRequest {
+    let payload = setRequirementCall {
+        serviceType: service_type_id(service_type),
+        requirement,
+    }
+    .abi_encode();
+    call_payload(service_registry_address, payload)
+}
+
+/// Set the burn charged for registering an entry under `service_type`.
+pub fn set_self_registration_burn_payload(
+    service_registry_address: Address,
+    service_type: &ServiceType,
+    amount: U256,
+) -> TransactionRequest {
+    let payload = setSelfRegistrationBurnCall {
+        serviceType: service_type_id(service_type),
+        amount,
+    }
+    .abi_encode();
+    call_payload(service_registry_address, payload)
+}
+
+/// Set the burn charged for updating an entry under `service_type`.
+pub fn set_self_update_burn_payload(
+    service_registry_address: Address,
+    service_type: &ServiceType,
+    amount: U256,
+) -> TransactionRequest {
+    let payload = setSelfUpdateBurnCall {
+        serviceType: service_type_id(service_type),
+        amount,
+    }
+    .abi_encode();
+    call_payload(service_registry_address, payload)
+}
+
+/// Hand ownership of `service_type` to `new_owner`.
+///
+/// The zero address abandons the type, which is one way and unrecoverable (RFC section 3.1), and
+/// so is a wrong live address. The caller is responsible for confirming the target.
+pub fn transfer_service_type_ownership_payload(
+    service_registry_address: Address,
+    service_type: &ServiceType,
+    new_owner: Address,
+) -> TransactionRequest {
+    let payload = transferTypeOwnershipCall {
+        serviceType: service_type_id(service_type),
+        newOwner: new_owner,
+    }
+    .abi_encode();
+    call_payload(service_registry_address, payload)
+}
+
+/// Set the global fee charged for registering a new service type.
+pub fn set_type_registration_fee_payload(service_registry_address: Address, amount: U256) -> TransactionRequest {
+    call_payload(
+        service_registry_address,
+        setTypeRegistrationFeeCall { amount }.abi_encode(),
+    )
+}
+
+/// Repoint the registry at another node-safe registry.
+///
+/// The contract probes the new registry with `probe_node` and requires it to resolve to
+/// `expected_safe`, which keeps a typo from silently orphaning every entry.
+pub fn set_node_safe_registry_payload(
+    service_registry_address: Address,
+    node_safe_registry: Address,
+    probe_node: Address,
+    expected_safe: Address,
+) -> TransactionRequest {
+    let payload = setNodeSafeRegistryCall {
+        nodeSafeRegistry_: node_safe_registry,
+        probeNode: probe_node,
+        expectedSafe: expected_safe,
+    }
+    .abi_encode();
+    call_payload(service_registry_address, payload)
+}
+
+/// Sweep tokens that were transferred to the registry by mistake.
+pub fn recover_service_registry_tokens_payload(
+    service_registry_address: Address,
+    token: Address,
+    to: Address,
+) -> TransactionRequest {
+    call_payload(service_registry_address, recoverTokensCall { token, to }.abi_encode())
+}
+
 #[cfg(test)]
 mod tests {
+    use hex_literal::hex;
+
     use super::*;
+
+    /// `bytes32("gvpn:exit")`, the canonical GnosisVPN exit-node type id.
+    const SERVICE_TYPE: ServiceType = ServiceType::GVPN_EXIT;
+    const NODE: Address = Address::new(hex!("00000000000000000000000000000000000000aa"));
+    const REQUIREMENT: Address = Address::new(hex!("00000000000000000000000000000000000000bb"));
+    const NEW_OWNER: Address = Address::new(hex!("00000000000000000000000000000000000000cc"));
+    const SPENDER: Address = Address::new(hex!("00000000000000000000000000000000000000dd"));
+    const NODE_SAFE_REGISTRY: Address = Address::new(hex!("00000000000000000000000000000000000000e1"));
+    const PROBE_NODE: Address = Address::new(hex!("00000000000000000000000000000000000000e2"));
+    const EXPECTED_SAFE: Address = Address::new(hex!("00000000000000000000000000000000000000e3"));
+    const TOKEN: Address = Address::new(hex!("00000000000000000000000000000000000000f1"));
+    const RECIPIENT: Address = Address::new(hex!("00000000000000000000000000000000000000f2"));
+    /// The contract under test, only ever the `to` of the request, never part of the calldata.
+    const REGISTRY: Address = Address::new(hex!("0000000000000000000000000000000000000001"));
+
+    /// 1 wxHOPR, `0x0de0b6b3a7640000`.
+    fn one_token() -> U256 {
+        U256::from(1_000_000_000_000_000_000u64)
+    }
+
+    /// 0.5 wxHOPR, `0x06f05b59d3b20000`.
+    fn half_token() -> U256 {
+        U256::from(500_000_000_000_000_000u64)
+    }
+
+    /// Returns the calldata of `tx`, asserting it targets `expected_to`.
+    fn calldata(tx: &TransactionRequest, expected_to: Address) -> Vec<u8> {
+        assert_eq!(
+            tx.to.and_then(|kind| kind.to().copied()),
+            Some(expected_to),
+            "payload targets the wrong contract"
+        );
+        tx.input.input().expect("payload carries no calldata").to_vec()
+    }
+
+    // Every expected vector below was derived by hand, not read back from the bindings:
+    // selector = first 4 bytes of keccak256 of the canonical signature, followed by the standard
+    // ABI head/tail encoding of the arguments - one 32-byte word per static argument (addresses
+    // right-aligned, `bytes32` left-aligned as stored), and for `bytes` a head word holding the
+    // tail offset plus a tail of the length word followed by the right-padded data.
+
+    #[test]
+    fn test_self_register_service_payload_calldata() -> anyhow::Result<()> {
+        // keccak256("selfRegister(bytes32,address,bytes)")[..4] = 0x326005af; three head words
+        // (type, node, tail offset 0x60) then the `bytes` tail (length 5, "hello" right-padded).
+        let expected = hex!(
+            "326005af"
+            "6776706e3a657869740000000000000000000000000000000000000000000000"
+            "00000000000000000000000000000000000000000000000000000000000000aa"
+            "0000000000000000000000000000000000000000000000000000000000000060"
+            "0000000000000000000000000000000000000000000000000000000000000005"
+            "68656c6c6f000000000000000000000000000000000000000000000000000000"
+        );
+
+        let metadata = ServiceMetadata::try_from(b"hello".to_vec())?;
+        let tx = self_register_service_payload(REGISTRY, &SERVICE_TYPE, NODE, &metadata);
+        assert_eq!(calldata(&tx, REGISTRY), expected.to_vec());
+        Ok(())
+    }
+
+    #[test]
+    fn test_self_update_service_payload_calldata() -> anyhow::Result<()> {
+        // keccak256("selfUpdate(bytes32,address,bytes)")[..4] = 0x210c3298; argument encoding is
+        // identical to `selfRegister`.
+        let expected = hex!(
+            "210c3298"
+            "6776706e3a657869740000000000000000000000000000000000000000000000"
+            "00000000000000000000000000000000000000000000000000000000000000aa"
+            "0000000000000000000000000000000000000000000000000000000000000060"
+            "0000000000000000000000000000000000000000000000000000000000000005"
+            "68656c6c6f000000000000000000000000000000000000000000000000000000"
+        );
+
+        let metadata = ServiceMetadata::try_from(b"hello".to_vec())?;
+        let tx = self_update_service_payload(REGISTRY, &SERVICE_TYPE, NODE, &metadata);
+        assert_eq!(calldata(&tx, REGISTRY), expected.to_vec());
+        Ok(())
+    }
+
+    #[test]
+    fn test_self_deregister_service_payload_calldata() {
+        // keccak256("selfDeregister(bytes32,address)")[..4] = 0x1e46f907; two static words.
+        let expected = hex!(
+            "1e46f907"
+            "6776706e3a657869740000000000000000000000000000000000000000000000"
+            "00000000000000000000000000000000000000000000000000000000000000aa"
+        );
+
+        let tx = self_deregister_service_payload(REGISTRY, &SERVICE_TYPE, NODE);
+        assert_eq!(calldata(&tx, REGISTRY), expected.to_vec());
+    }
+
+    #[test]
+    fn test_register_service_type_payload_calldata() {
+        // keccak256("registerServiceType(bytes32,address,uint256,uint256)")[..4] = 0x0ff55869;
+        // four static words: type, requirement, 1e18 (0x0de0b6b3a7640000), 5e17 (0x06f05b59d3b20000).
+        let expected = hex!(
+            "0ff55869"
+            "6776706e3a657869740000000000000000000000000000000000000000000000"
+            "00000000000000000000000000000000000000000000000000000000000000bb"
+            "0000000000000000000000000000000000000000000000000de0b6b3a7640000"
+            "00000000000000000000000000000000000000000000000006f05b59d3b20000"
+        );
+
+        let tx = register_service_type_payload(REGISTRY, &SERVICE_TYPE, REQUIREMENT, one_token(), half_token());
+        assert_eq!(calldata(&tx, REGISTRY), expected.to_vec());
+    }
+
+    #[test]
+    fn test_set_service_type_requirement_payload_calldata() {
+        // keccak256("setRequirement(bytes32,address)")[..4] = 0x326d1f22.
+        let expected = hex!(
+            "326d1f22"
+            "6776706e3a657869740000000000000000000000000000000000000000000000"
+            "00000000000000000000000000000000000000000000000000000000000000bb"
+        );
+
+        let tx = set_service_type_requirement_payload(REGISTRY, &SERVICE_TYPE, REQUIREMENT);
+        assert_eq!(calldata(&tx, REGISTRY), expected.to_vec());
+    }
+
+    #[test]
+    fn test_set_self_registration_burn_payload_calldata() {
+        // keccak256("setSelfRegistrationBurn(bytes32,uint256)")[..4] = 0xf13217a9.
+        let expected = hex!(
+            "f13217a9"
+            "6776706e3a657869740000000000000000000000000000000000000000000000"
+            "0000000000000000000000000000000000000000000000000de0b6b3a7640000"
+        );
+
+        let tx = set_self_registration_burn_payload(REGISTRY, &SERVICE_TYPE, one_token());
+        assert_eq!(calldata(&tx, REGISTRY), expected.to_vec());
+    }
+
+    #[test]
+    fn test_set_self_update_burn_payload_calldata() {
+        // keccak256("setSelfUpdateBurn(bytes32,uint256)")[..4] = 0x1cd0ad00.
+        let expected = hex!(
+            "1cd0ad00"
+            "6776706e3a657869740000000000000000000000000000000000000000000000"
+            "00000000000000000000000000000000000000000000000006f05b59d3b20000"
+        );
+
+        let tx = set_self_update_burn_payload(REGISTRY, &SERVICE_TYPE, half_token());
+        assert_eq!(calldata(&tx, REGISTRY), expected.to_vec());
+    }
+
+    #[test]
+    fn test_transfer_service_type_ownership_payload_calldata() {
+        // keccak256("transferTypeOwnership(bytes32,address)")[..4] = 0x47ce2eef.
+        let expected = hex!(
+            "47ce2eef"
+            "6776706e3a657869740000000000000000000000000000000000000000000000"
+            "00000000000000000000000000000000000000000000000000000000000000cc"
+        );
+
+        let tx = transfer_service_type_ownership_payload(REGISTRY, &SERVICE_TYPE, NEW_OWNER);
+        assert_eq!(calldata(&tx, REGISTRY), expected.to_vec());
+    }
+
+    #[test]
+    fn test_transfer_service_type_ownership_payload_abandons_with_zero_address() {
+        // Same selector, with the new owner word all zeroes: the one-way abandonment of RFC 3.1.
+        let expected = hex!(
+            "47ce2eef"
+            "6776706e3a657869740000000000000000000000000000000000000000000000"
+            "0000000000000000000000000000000000000000000000000000000000000000"
+        );
+
+        let tx = transfer_service_type_ownership_payload(REGISTRY, &SERVICE_TYPE, Address::ZERO);
+        assert_eq!(calldata(&tx, REGISTRY), expected.to_vec());
+    }
+
+    #[test]
+    fn test_set_type_registration_fee_payload_calldata() {
+        // keccak256("setTypeRegistrationFee(uint256)")[..4] = 0xb3f618d1; 2e18 = 0x1bc16d674ec80000.
+        let expected = hex!(
+            "b3f618d1"
+            "0000000000000000000000000000000000000000000000001bc16d674ec80000"
+        );
+
+        let tx = set_type_registration_fee_payload(REGISTRY, U256::from(2_000_000_000_000_000_000u64));
+        assert_eq!(calldata(&tx, REGISTRY), expected.to_vec());
+    }
+
+    #[test]
+    fn test_set_node_safe_registry_payload_calldata() {
+        // keccak256("setNodeSafeRegistry(address,address,address)")[..4] = 0x48559a57.
+        let expected = hex!(
+            "48559a57"
+            "00000000000000000000000000000000000000000000000000000000000000e1"
+            "00000000000000000000000000000000000000000000000000000000000000e2"
+            "00000000000000000000000000000000000000000000000000000000000000e3"
+        );
+
+        let tx = set_node_safe_registry_payload(REGISTRY, NODE_SAFE_REGISTRY, PROBE_NODE, EXPECTED_SAFE);
+        assert_eq!(calldata(&tx, REGISTRY), expected.to_vec());
+    }
+
+    #[test]
+    fn test_recover_service_registry_tokens_payload_calldata() {
+        // keccak256("recoverTokens(address,address)")[..4] = 0x056097ac.
+        let expected = hex!(
+            "056097ac"
+            "00000000000000000000000000000000000000000000000000000000000000f1"
+            "00000000000000000000000000000000000000000000000000000000000000f2"
+        );
+
+        let tx = recover_service_registry_tokens_payload(REGISTRY, TOKEN, RECIPIENT);
+        assert_eq!(calldata(&tx, REGISTRY), expected.to_vec());
+    }
+
+    #[test]
+    fn test_approve_hopr_token_payload_calldata() {
+        // keccak256("approve(address,uint256)")[..4] = 0x095ea7b3; spender then the exact amount.
+        let expected = hex!(
+            "095ea7b3"
+            "00000000000000000000000000000000000000000000000000000000000000dd"
+            "0000000000000000000000000000000000000000000000000de0b6b3a7640000"
+        );
+
+        let tx = approve_hopr_token_payload(TOKEN, SPENDER, one_token());
+        assert_eq!(calldata(&tx, TOKEN), expected.to_vec());
+    }
 
     #[test]
     fn test_edge_node_deploy_safe_module_and_maybe_include_node() -> anyhow::Result<()> {

--- a/src/safe_module.rs
+++ b/src/safe_module.rs
@@ -90,7 +90,7 @@
 //!     --module-address 0x5d46d0c5279fd85ce7365e4d668f415685922839 \
 //!     --provider-url "http://localhost:8545"
 //! ```
-//!
+//! 
 //! - Replace a module with a new module (v4 compatible) and include nodes in the new one
 //! ```text
 //! hopli safe-module replace \
@@ -105,7 +105,7 @@
 //!     --private-key 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d \
 //!     --provider-url "http://localhost:8545"
 //! ```
-//!
+//! 
 //! - Create a new module (v4 compatible) and adds nodes to the new module
 //! ```text
 //! hopli safe-module new-module \
@@ -119,14 +119,14 @@
 //!     --private-key 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d \
 //!     --provider-url "http://localhost:8545"
 //! ```
-//!
+//! 
 //! - Inspect a safe and report its setup, which network it matches, and linked nodes
 //! ```text
 //! hopli safe-module check-safe \
 //!     --safe-address 0xce66d19a86600f3c6eb61edd6c431ded5cc92b21 \
 //!     --provider-url "https://gnosis-rpc.example/"
 //! ```
-//!
+//! 
 //! - Add an existing node identity to an existing safe and module
 //! ```text
 //! hopli safe-module add-node \
@@ -139,7 +139,7 @@
 //!     --private-key 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d \
 //!     --provider-url "http://localhost:8545"
 //! ```
-//!
+//! 
 //! - Add a new contract target to the module
 //! ```text
 //! hopli safe-module add-target \
@@ -1261,7 +1261,8 @@ impl SafeModuleSubcommands {
                             .collect();
                         if !expected.is_empty() {
                             warn!(
-                                "  service registry target not set — run `safe-module add-service-registry-target` ({:?})",
+                                "  service registry target not set — run `safe-module add-service-registry-target` \
+                                 ({:?})",
                                 expected
                             );
                         }

--- a/src/safe_module.rs
+++ b/src/safe_module.rs
@@ -90,7 +90,7 @@
 //!     --module-address 0x5d46d0c5279fd85ce7365e4d668f415685922839 \
 //!     --provider-url "http://localhost:8545"
 //! ```
-//! 
+//!
 //! - Replace a module with a new module (v4 compatible) and include nodes in the new one
 //! ```text
 //! hopli safe-module replace \
@@ -105,7 +105,7 @@
 //!     --private-key 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d \
 //!     --provider-url "http://localhost:8545"
 //! ```
-//! 
+//!
 //! - Create a new module (v4 compatible) and adds nodes to the new module
 //! ```text
 //! hopli safe-module new-module \
@@ -119,14 +119,14 @@
 //!     --private-key 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d \
 //!     --provider-url "http://localhost:8545"
 //! ```
-//! 
+//!
 //! - Inspect a safe and report its setup, which network it matches, and linked nodes
 //! ```text
 //! hopli safe-module check-safe \
 //!     --safe-address 0xce66d19a86600f3c6eb61edd6c431ded5cc92b21 \
 //!     --provider-url "https://gnosis-rpc.example/"
 //! ```
-//! 
+//!
 //! - Add an existing node identity to an existing safe and module
 //! ```text
 //! hopli safe-module add-node \
@@ -139,7 +139,7 @@
 //!     --private-key 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d \
 //!     --provider-url "http://localhost:8545"
 //! ```
-//! 
+//!
 //! - Add a new contract target to the module
 //! ```text
 //! hopli safe-module add-target \
@@ -169,11 +169,12 @@ use crate::{
     environment_config::NetworkProviderArgs,
     key_pair::{ArgEnvReader, IdentityFileArgs, ManagerPrivateKeyArgs, PrivateKeyArgs},
     methods::{
-        SafeSingleton, add_new_network_target_to_module, check_safe_setup, create_new_module_and_include_nodes,
-        create_new_module_include_nodes_and_remove_old_module, debug_node_safe_module_setup_main,
-        debug_node_safe_module_setup_on_balance_and_registries, deploy_safe_module_with_targets_and_nodes,
-        deregister_nodes_from_node_safe_registry_and_remove_from_module, fill_node_registry_status,
-        include_nodes_to_module, migrate_nodes, transfer_native_tokens, transfer_or_mint_tokens,
+        SafeSingleton, add_new_network_target_to_module, add_service_registry_target_to_module, check_safe_setup,
+        create_new_module_and_include_nodes, create_new_module_include_nodes_and_remove_old_module,
+        debug_node_safe_module_setup_main, debug_node_safe_module_setup_on_balance_and_registries,
+        deploy_safe_module_with_targets_and_nodes, deregister_nodes_from_node_safe_registry_and_remove_from_module,
+        fill_node_registry_status, include_nodes_to_module, migrate_nodes, transfer_native_tokens,
+        transfer_or_mint_tokens,
     },
     utils::{Cmd, HelperErrors, a2h},
 };
@@ -471,6 +472,26 @@ pub enum SafeModuleSubcommands {
 
         /// Access to the private key, of which the wallet either contains sufficient assets
         /// as the source of funds or it can mint necessary tokens
+        #[command(flatten)]
+        private_key: PrivateKeyArgs,
+    },
+
+    /// Scope the current network's service registry on an existing module
+    #[command(visible_alias = "asr")]
+    AddServiceRegistryTarget {
+        /// Network name, contracts config file root, and customized provider, if available
+        #[command(flatten)]
+        network_provider: NetworkProviderArgs,
+
+        /// Safe that owns the node-management module
+        #[clap(help = "Safe address that owns the module", long, short = 's')]
+        safe_address: String,
+
+        /// HOPR node-management module address
+        #[clap(help = "HOPR node-management module address", long, short = 'm')]
+        module_address: String,
+
+        /// Access to the private key of a Safe owner
         #[command(flatten)]
         private_key: PrivateKeyArgs,
     },
@@ -1057,6 +1078,38 @@ impl SafeModuleSubcommands {
         Ok(())
     }
 
+    /// Scope the configured service registry on an existing module through its owning Safe.
+    pub async fn execute_add_service_registry_target(
+        network_provider: NetworkProviderArgs,
+        safe_address: String,
+        module_address: String,
+        private_key: PrivateKeyArgs,
+    ) -> Result<(), HelperErrors> {
+        let safe_addr = Address::from_str(&safe_address)
+            .map_err(|_| HelperErrors::InvalidAddress(format!("Cannot parse safe address {safe_address:?}")))?;
+        let module_addr = Address::from_str(&module_address)
+            .map_err(|_| HelperErrors::InvalidAddress(format!("Cannot parse module address {module_address:?}")))?;
+
+        let signer_private_key = private_key.read_default()?;
+        let rpc_provider = network_provider.get_provider_with_signer(&signer_private_key).await?;
+        let contract_addresses = network_provider.get_network_details_from_name()?;
+        let service_registry = contract_addresses.addresses.service_registry;
+        if service_registry.is_zero() {
+            return Err(HelperErrors::ContractNotDeployed(format!(
+                "HoprServiceRegistry is not deployed on network {}",
+                network_provider.network
+            )));
+        }
+
+        add_service_registry_target_to_module(
+            SafeSingleton::new(safe_addr, rpc_provider),
+            module_addr,
+            service_registry,
+            signer_private_key,
+        )
+        .await
+    }
+
     /// Execute the command which inspects a Safe and reports its setup,
     /// attached HOPR module, linked nodes, and the matching network configuration.
     pub async fn execute_safe_module_check_safe(
@@ -1129,6 +1182,7 @@ impl SafeModuleSubcommands {
                 let mut found_channels: Option<(Address, Vec<&str>)> = None;
                 let mut found_announcement: Option<(Address, Vec<&str>)> = None;
                 let mut found_token: Option<(Address, Vec<&str>)> = None;
+                let mut found_service_registry: Option<(Address, Vec<&str>)> = None;
                 let mut unknowns: Vec<(Address, u8)> = Vec::new();
 
                 for (addr, ty) in &m.targets {
@@ -1144,6 +1198,13 @@ impl SafeModuleSubcommands {
                         .iter()
                         .filter_map(|(n, c)| (c.addresses.token == *addr).then_some(n.as_str()))
                         .collect();
+                    let svc: Vec<&str> = candidates
+                        .iter()
+                        .filter_map(|(n, c)| {
+                            (!c.addresses.service_registry.is_zero() && c.addresses.service_registry == *addr)
+                                .then_some(n.as_str())
+                        })
+                        .collect();
 
                     if !ch.is_empty() {
                         found_channels = Some((*addr, ch));
@@ -1151,6 +1212,8 @@ impl SafeModuleSubcommands {
                         found_announcement = Some((*addr, ann));
                     } else if !tok.is_empty() {
                         found_token = Some((*addr, tok));
+                    } else if !svc.is_empty() {
+                        found_service_registry = Some((*addr, svc));
                     } else {
                         unknowns.push((*addr, *ty));
                     }
@@ -1178,6 +1241,32 @@ impl SafeModuleSubcommands {
 
                 if let Some((a, _)) = &found_token {
                     info!("  wxHOPR token target scoped: {:?}", a);
+                }
+                match (&found_service_registry, channels_nets) {
+                    (Some((a, svc)), Some(ch)) if svc.iter().any(|network| ch.contains(network)) => {
+                        info!("  service registry target scoped: {:?}", a);
+                    }
+                    (Some((a, svc)), _) => warn!(
+                        "  service registry target {:?} points to a DIFFERENT network ({}) than channels",
+                        a,
+                        svc.join(", ")
+                    ),
+                    (None, Some(ch)) => {
+                        let expected: Vec<_> = candidates
+                            .iter()
+                            .filter(|(name, config)| {
+                                ch.contains(&name.as_str()) && !config.addresses.service_registry.is_zero()
+                            })
+                            .map(|(name, config)| (name.as_str(), config.addresses.service_registry))
+                            .collect();
+                        if !expected.is_empty() {
+                            warn!(
+                                "  service registry target not set — run `safe-module add-service-registry-target` ({:?})",
+                                expected
+                            );
+                        }
+                    }
+                    (None, None) => {}
                 }
                 for (a, ty) in &unknowns {
                     warn!("  unrecognised target {:?} (target_type byte {:#04x})", a, ty);
@@ -1402,6 +1491,20 @@ impl Cmd for SafeModuleSubcommands {
                 private_key,
             } => {
                 SafeModuleSubcommands::execute_safe_create_add_new_target(
+                    network_provider,
+                    safe_address,
+                    module_address,
+                    private_key,
+                )
+                .await
+            }
+            SafeModuleSubcommands::AddServiceRegistryTarget {
+                network_provider,
+                safe_address,
+                module_address,
+                private_key,
+            } => {
+                SafeModuleSubcommands::execute_add_service_registry_target(
                     network_provider,
                     safe_address,
                     module_address,

--- a/src/service.rs
+++ b/src/service.rs
@@ -3,16 +3,15 @@
 //!
 //! The commands fall into three groups, which differ in who has to sign them:
 //!
-//! - **Entry writes** (`register`, `update`, `deregister`). The registry accepts these only from
-//!   the Safe bound to the node in the node-safe registry, so they are sent as a Safe transaction
-//!   rather than from an EOA. `register` and `update` cost the type's burn in wxHOPR, so they are
-//!   batched behind an exact `approve` in the same MultiSend. `deregister` is free and needs no
-//!   approval, so that a bound node can always delist itself.
-//! - **Type-owner writes** (`register-type`, `set-requirement`, `set-registration-burn`,
-//!   `set-update-burn`, `transfer-type-ownership`) and **admin/manager writes** (`set-fee`,
-//!   `set-node-safe-registry`, `recover-tokens`). These come straight from the caller's key.
-//! - **Reads** (`get`, `list`, `types`). Plain view calls. Both list views are paginated and their
-//!   order is unstable, so a scan pins every one of its pages to a single block.
+//! - **Entry writes** (`register`, `update`, `deregister`). The registry accepts these only from the Safe bound to the
+//!   node in the node-safe registry, so they are sent as a Safe transaction rather than from an EOA. `register` and
+//!   `update` cost the type's burn in wxHOPR, so they are batched behind an exact `approve` in the same MultiSend.
+//!   `deregister` is free and needs no approval, so that a bound node can always delist itself.
+//! - **Type-owner writes** (`register-type`, `set-requirement`, `set-registration-burn`, `set-update-burn`,
+//!   `transfer-type-ownership`) and **admin/manager writes** (`set-fee`, `set-node-safe-registry`, `recover-tokens`).
+//!   These come straight from the caller's key.
+//! - **Reads** (`get`, `list`, `types`). Plain view calls. Both list views are paginated and their order is unstable,
+//!   so a scan pins every one of its pages to a single block.
 //!
 //! Some sample commands:
 //! - Register a node under a service type, through the node's Safe:

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,1969 @@
+//! This module contains arguments and functions to interact with `HoprServiceRegistry`, the
+//! permissionless on-chain registry of the services that HOPR nodes offer.
+//!
+//! The commands fall into three groups, which differ in who has to sign them:
+//!
+//! - **Entry writes** (`register`, `update`, `deregister`). The registry accepts these only from
+//!   the Safe bound to the node in the node-safe registry, so they are sent as a Safe transaction
+//!   rather than from an EOA. `register` and `update` cost the type's burn in wxHOPR, so they are
+//!   batched behind an exact `approve` in the same MultiSend. `deregister` is free and needs no
+//!   approval, so that a bound node can always delist itself.
+//! - **Type-owner writes** (`register-type`, `set-requirement`, `set-registration-burn`,
+//!   `set-update-burn`, `transfer-type-ownership`) and **admin/manager writes** (`set-fee`,
+//!   `set-node-safe-registry`, `recover-tokens`). These come straight from the caller's key.
+//! - **Reads** (`get`, `list`, `types`). Plain view calls. Both list views are paginated and their
+//!   order is unstable, so a scan pins every one of its pages to a single block.
+//!
+//! Some sample commands:
+//! - Register a node under a service type, through the node's Safe:
+//! ```shell
+//! hopli service register \
+//!     --network anvil-localhost \
+//!     --service-type gvpn:exit \
+//!     --node-address 0x0123... \
+//!     --metadata '{"endpoint":"https://exit.example"}' \
+//!     --private-key <SAFE_OWNER_PRIVATE_KEY> \
+//!     --provider-url "http://localhost:8545"
+//! ```
+//! - Read a single entry:
+//! ```shell
+//! hopli service get \
+//!     --network anvil-localhost \
+//!     --service-type gvpn:exit \
+//!     --node-address 0x0123... \
+//!     --provider-url "http://localhost:8545"
+//! ```
+//! - Claim a service type and become its owner:
+//! ```shell
+//! hopli service register-type \
+//!     --network anvil-localhost \
+//!     --service-type gvpn:exit \
+//!     --registration-burn 1 \
+//!     --update-burn 0.5 \
+//!     --private-key <PRIVATE_KEY> \
+//!     --provider-url "http://localhost:8545"
+//! ```
+use std::{path::PathBuf, str::FromStr, sync::Arc};
+
+use clap::{Parser, builder::ValueParser};
+use hopr_bindings::{
+    ContractAddresses,
+    constants::SAFE_MULTISEND_ADDRESS,
+    exports::alloy::{
+        eips::BlockId,
+        primitives::{Address, B256, U256, utils::parse_units},
+        providers::Provider,
+        rpc::types::TransactionRequest,
+    },
+    hopr_node_safe_registry::HoprNodeSafeRegistry,
+    hopr_service_registry::HoprServiceRegistry::{self, Entry},
+};
+use hopr_types::{
+    crypto::keypairs::ChainKeypair,
+    internal::prelude::{ServiceMetadata, ServiceType},
+    primitive::prelude::ToHex,
+};
+use tracing::info;
+
+use crate::{
+    environment_config::{NetworkProviderArgs, RpcProvider},
+    key_pair::{ArgEnvReader, PrivateKeyArgs},
+    methods::{
+        MultisendTransaction, SafeSingleton, SafeTxOperation, get_chain_id_and_safe_nonce,
+        send_multisend_safe_transaction_with_threshold_one,
+    },
+    payloads::{
+        approve_hopr_token_payload, recover_service_registry_tokens_payload, register_service_type_payload,
+        self_deregister_service_payload, self_register_service_payload, self_update_service_payload,
+        set_node_safe_registry_payload, set_self_registration_burn_payload, set_self_update_burn_payload,
+        set_service_type_requirement_payload, set_type_registration_fee_payload,
+        transfer_service_type_ownership_payload,
+    },
+    utils::{Cmd, HelperErrors},
+};
+
+/// Number of entries or types read per page when a list command scans the registry.
+const DEFAULT_PAGE_SIZE: u64 = 100;
+
+/// Parses a service type from its ASCII name, or from a full `0x` prefixed 32-byte id.
+///
+/// The `0x` prefix decides which reading applies, rather than the hex reading being a fallback
+/// for names that fail to parse. Both readings accept a short input such as `0xab`, and taking it
+/// as the name "0xab" would silently register under a different type than the caller meant.
+fn parse_service_type(s: &str) -> Result<ServiceType, String> {
+    if s.starts_with("0x") || s.starts_with("0X") {
+        ServiceType::from_hex(s).map_err(|e| format!("invalid 32-byte service type id: {e}"))
+    } else {
+        ServiceType::from_str(s).map_err(|e| format!("invalid service type name: {e}"))
+    }
+}
+
+/// Parses entry metadata from the bytes of the given string, enforcing the registry's length cap.
+fn parse_service_metadata(s: &str) -> Result<ServiceMetadata, String> {
+    ServiceMetadata::try_from(s.as_bytes().to_vec()).map_err(|e| format!("invalid service metadata: {e}"))
+}
+
+/// Parses a wxHOPR amount given in whole tokens, for example `1.5`, into wei.
+fn parse_hopr_amount(s: &str) -> Result<U256, String> {
+    let amount: U256 = parse_units(s, "ether")
+        .map_err(|e| format!("invalid wxHOPR amount: {e}"))?
+        .into();
+    Ok(amount)
+}
+
+/// CLI arguments for `hopli service`
+#[derive(Clone, Debug, Parser)]
+pub enum ServiceSubcommands {
+    /// Register a node under a service type, from the node's bound Safe
+    #[command(visible_alias = "r")]
+    Register {
+        /// Network name, contracts config file root, and customized provider, if available
+        #[command(flatten)]
+        network_provider: NetworkProviderArgs,
+
+        /// Service type, either an ASCII name such as `gvpn:exit` or a `0x` prefixed 32-byte id
+        #[clap(
+            help = "Service type, e.g. gvpn:exit or a 0x-prefixed 32-byte id",
+            long,
+            short = 't',
+            value_parser = ValueParser::new(parse_service_type)
+        )]
+        service_type: ServiceType,
+
+        /// Node whose entry is written
+        #[clap(help = "Ethereum address of the node", long, short = 'o')]
+        node_address: Address,
+
+        /// Safe bound to the node; read from the node-safe registry when omitted
+        #[clap(
+            help = "Safe that sends the transaction; defaults to the safe bound to the node",
+            long,
+            short = 's'
+        )]
+        safe_address: Option<Address>,
+
+        /// Entry metadata, given inline
+        #[command(flatten)]
+        metadata: MetadataArgs,
+
+        /// Access to the private key of an owner of the node's Safe
+        #[command(flatten)]
+        private_key: PrivateKeyArgs,
+    },
+
+    /// Replace the metadata of an existing entry, from the node's bound Safe
+    #[command(visible_alias = "u")]
+    Update {
+        /// Network name, contracts config file root, and customized provider, if available
+        #[command(flatten)]
+        network_provider: NetworkProviderArgs,
+
+        /// Service type, either an ASCII name such as `gvpn:exit` or a `0x` prefixed 32-byte id
+        #[clap(
+            help = "Service type, e.g. gvpn:exit or a 0x-prefixed 32-byte id",
+            long,
+            short = 't',
+            value_parser = ValueParser::new(parse_service_type)
+        )]
+        service_type: ServiceType,
+
+        /// Node whose entry is written
+        #[clap(help = "Ethereum address of the node", long, short = 'o')]
+        node_address: Address,
+
+        /// Safe bound to the node; read from the node-safe registry when omitted
+        #[clap(
+            help = "Safe that sends the transaction; defaults to the safe bound to the node",
+            long,
+            short = 's'
+        )]
+        safe_address: Option<Address>,
+
+        /// New entry metadata
+        #[command(flatten)]
+        metadata: MetadataArgs,
+
+        /// Access to the private key of an owner of the node's Safe
+        #[command(flatten)]
+        private_key: PrivateKeyArgs,
+    },
+
+    /// Remove an entry, from the node's bound Safe. Free, and never gated by the type's policy
+    #[command(visible_alias = "d")]
+    Deregister {
+        /// Network name, contracts config file root, and customized provider, if available
+        #[command(flatten)]
+        network_provider: NetworkProviderArgs,
+
+        /// Service type, either an ASCII name such as `gvpn:exit` or a `0x` prefixed 32-byte id
+        #[clap(
+            help = "Service type, e.g. gvpn:exit or a 0x-prefixed 32-byte id",
+            long,
+            short = 't',
+            value_parser = ValueParser::new(parse_service_type)
+        )]
+        service_type: ServiceType,
+
+        /// Node whose entry is removed
+        #[clap(help = "Ethereum address of the node", long, short = 'o')]
+        node_address: Address,
+
+        /// Safe bound to the node; read from the node-safe registry when omitted
+        #[clap(
+            help = "Safe that sends the transaction; defaults to the safe bound to the node",
+            long,
+            short = 's'
+        )]
+        safe_address: Option<Address>,
+
+        /// Access to the private key of an owner of the node's Safe
+        #[command(flatten)]
+        private_key: PrivateKeyArgs,
+    },
+
+    /// Read a single entry
+    #[command(visible_alias = "g")]
+    Get {
+        /// Network name, contracts config file root, and customized provider, if available
+        #[command(flatten)]
+        network_provider: NetworkProviderArgs,
+
+        /// Service type, either an ASCII name such as `gvpn:exit` or a `0x` prefixed 32-byte id
+        #[clap(
+            help = "Service type, e.g. gvpn:exit or a 0x-prefixed 32-byte id",
+            long,
+            short = 't',
+            value_parser = ValueParser::new(parse_service_type)
+        )]
+        service_type: ServiceType,
+
+        /// Node to look up
+        #[clap(help = "Ethereum address of the node", long, short = 'o')]
+        node_address: Address,
+    },
+
+    /// List the entries registered under a service type
+    #[command(visible_alias = "l")]
+    List {
+        /// Network name, contracts config file root, and customized provider, if available
+        #[command(flatten)]
+        network_provider: NetworkProviderArgs,
+
+        /// Service type, either an ASCII name such as `gvpn:exit` or a `0x` prefixed 32-byte id
+        #[clap(
+            help = "Service type, e.g. gvpn:exit or a 0x-prefixed 32-byte id",
+            long,
+            short = 't',
+            value_parser = ValueParser::new(parse_service_type)
+        )]
+        service_type: ServiceType,
+
+        /// Pagination arguments
+        #[command(flatten)]
+        pagination: PaginationArgs,
+    },
+
+    /// List the registered service types
+    Types {
+        /// Network name, contracts config file root, and customized provider, if available
+        #[command(flatten)]
+        network_provider: NetworkProviderArgs,
+
+        /// Pagination arguments
+        #[command(flatten)]
+        pagination: PaginationArgs,
+    },
+
+    /// Claim a service type and become its owner. Costs the global type registration fee
+    RegisterType {
+        /// Network name, contracts config file root, and customized provider, if available
+        #[command(flatten)]
+        network_provider: NetworkProviderArgs,
+
+        /// Service type, either an ASCII name such as `gvpn:exit` or a `0x` prefixed 32-byte id
+        #[clap(
+            help = "Service type, e.g. gvpn:exit or a 0x-prefixed 32-byte id",
+            long,
+            short = 't',
+            value_parser = ValueParser::new(parse_service_type)
+        )]
+        service_type: ServiceType,
+
+        /// Requirement contract gating registration, or the zero address for an open type
+        #[clap(
+            help = "Requirement contract address; the zero address leaves the type open",
+            long,
+            default_value_t = Address::ZERO
+        )]
+        requirement: Address,
+
+        /// Burn charged for registering an entry, in whole wxHOPR
+        #[clap(
+            help = "Burn charged per registration, in whole wxHOPR",
+            long,
+            default_value = "0",
+            value_parser = ValueParser::new(parse_hopr_amount)
+        )]
+        registration_burn: U256,
+
+        /// Burn charged for updating an entry, in whole wxHOPR
+        #[clap(
+            help = "Burn charged per update, in whole wxHOPR",
+            long,
+            default_value = "0",
+            value_parser = ValueParser::new(parse_hopr_amount)
+        )]
+        update_burn: U256,
+
+        /// Access to the private key of the caller, who becomes the type owner
+        #[command(flatten)]
+        private_key: PrivateKeyArgs,
+    },
+
+    /// Point a service type at a requirement contract, as its owner
+    SetRequirement {
+        /// Network name, contracts config file root, and customized provider, if available
+        #[command(flatten)]
+        network_provider: NetworkProviderArgs,
+
+        /// Service type, either an ASCII name such as `gvpn:exit` or a `0x` prefixed 32-byte id
+        #[clap(
+            help = "Service type, e.g. gvpn:exit or a 0x-prefixed 32-byte id",
+            long,
+            short = 't',
+            value_parser = ValueParser::new(parse_service_type)
+        )]
+        service_type: ServiceType,
+
+        /// Requirement contract, or the zero address to open the type up
+        #[clap(
+            help = "Requirement contract address; the zero address opens the type up",
+            long,
+            default_value_t = Address::ZERO
+        )]
+        requirement: Address,
+
+        /// Access to the private key of the type owner
+        #[command(flatten)]
+        private_key: PrivateKeyArgs,
+    },
+
+    /// Set the registration burn of a service type, as its owner
+    SetRegistrationBurn {
+        /// Network name, contracts config file root, and customized provider, if available
+        #[command(flatten)]
+        network_provider: NetworkProviderArgs,
+
+        /// Service type, either an ASCII name such as `gvpn:exit` or a `0x` prefixed 32-byte id
+        #[clap(
+            help = "Service type, e.g. gvpn:exit or a 0x-prefixed 32-byte id",
+            long,
+            short = 't',
+            value_parser = ValueParser::new(parse_service_type)
+        )]
+        service_type: ServiceType,
+
+        /// New burn, in whole wxHOPR
+        #[clap(
+            help = "New registration burn, in whole wxHOPR",
+            long,
+            short = 'a',
+            value_parser = ValueParser::new(parse_hopr_amount)
+        )]
+        amount: U256,
+
+        /// Access to the private key of the type owner
+        #[command(flatten)]
+        private_key: PrivateKeyArgs,
+    },
+
+    /// Set the update burn of a service type, as its owner
+    SetUpdateBurn {
+        /// Network name, contracts config file root, and customized provider, if available
+        #[command(flatten)]
+        network_provider: NetworkProviderArgs,
+
+        /// Service type, either an ASCII name such as `gvpn:exit` or a `0x` prefixed 32-byte id
+        #[clap(
+            help = "Service type, e.g. gvpn:exit or a 0x-prefixed 32-byte id",
+            long,
+            short = 't',
+            value_parser = ValueParser::new(parse_service_type)
+        )]
+        service_type: ServiceType,
+
+        /// New burn, in whole wxHOPR
+        #[clap(
+            help = "New update burn, in whole wxHOPR",
+            long,
+            short = 'a',
+            value_parser = ValueParser::new(parse_hopr_amount)
+        )]
+        amount: U256,
+
+        /// Access to the private key of the type owner
+        #[command(flatten)]
+        private_key: PrivateKeyArgs,
+    },
+
+    /// Hand ownership of a service type to another address, as its owner
+    TransferTypeOwnership {
+        /// Network name, contracts config file root, and customized provider, if available
+        #[command(flatten)]
+        network_provider: NetworkProviderArgs,
+
+        /// Service type, either an ASCII name such as `gvpn:exit` or a `0x` prefixed 32-byte id
+        #[clap(
+            help = "Service type, e.g. gvpn:exit or a 0x-prefixed 32-byte id",
+            long,
+            short = 't',
+            value_parser = ValueParser::new(parse_service_type)
+        )]
+        service_type: ServiceType,
+
+        /// New owner of the type
+        #[clap(
+            help = "New owner of the service type",
+            long,
+            required_unless_present = "abandon",
+            conflicts_with = "abandon"
+        )]
+        new_owner: Option<Address>,
+
+        /// Abandon the type instead, leaving it without an owner forever
+        #[clap(
+            help = "Abandon the type by transferring it to the zero address. One way and unrecoverable",
+            long
+        )]
+        abandon: bool,
+
+        /// Access to the private key of the type owner
+        #[command(flatten)]
+        private_key: PrivateKeyArgs,
+    },
+
+    /// Set the global service type registration fee, as a manager
+    SetFee {
+        /// Network name, contracts config file root, and customized provider, if available
+        #[command(flatten)]
+        network_provider: NetworkProviderArgs,
+
+        /// New fee, in whole wxHOPR
+        #[clap(
+            help = "New type registration fee, in whole wxHOPR",
+            long,
+            short = 'a',
+            value_parser = ValueParser::new(parse_hopr_amount)
+        )]
+        amount: U256,
+
+        /// Access to the private key of a manager of the service registry
+        #[command(flatten)]
+        private_key: PrivateKeyArgs,
+    },
+
+    /// Repoint the registry at another node-safe registry, as the admin
+    SetNodeSafeRegistry {
+        /// Network name, contracts config file root, and customized provider, if available
+        #[command(flatten)]
+        network_provider: NetworkProviderArgs,
+
+        /// New node-safe registry
+        #[clap(help = "Address of the new node-safe registry", long)]
+        node_safe_registry: Address,
+
+        /// Node used to probe the new registry
+        #[clap(help = "Node whose binding is used to probe the new registry", long)]
+        probe_node: Address,
+
+        /// Safe that the probe node must resolve to in the new registry
+        #[clap(help = "Safe that the probe node must resolve to", long)]
+        expected_safe: Address,
+
+        /// Access to the private key of the admin of the service registry
+        #[command(flatten)]
+        private_key: PrivateKeyArgs,
+    },
+
+    /// Sweep tokens that were sent to the registry by mistake, as a manager
+    RecoverTokens {
+        /// Network name, contracts config file root, and customized provider, if available
+        #[command(flatten)]
+        network_provider: NetworkProviderArgs,
+
+        /// Token to sweep
+        #[clap(help = "Address of the token to recover", long)]
+        token: Address,
+
+        /// Recipient of the swept tokens
+        #[clap(help = "Address that receives the recovered tokens", long)]
+        recipient: Address,
+
+        /// Access to the private key of a manager of the service registry
+        #[command(flatten)]
+        private_key: PrivateKeyArgs,
+    },
+}
+
+/// Entry metadata, given either inline or as the contents of a file.
+///
+/// The file form is the only way to pass metadata that is not valid UTF-8.
+#[derive(Clone, Debug, Parser)]
+pub struct MetadataArgs {
+    /// Metadata bytes, given as a string
+    #[clap(
+        help = "Entry metadata, as a string of at most 2048 bytes",
+        long,
+        short = 'm',
+        value_parser = ValueParser::new(parse_service_metadata)
+    )]
+    pub metadata: Option<ServiceMetadata>,
+
+    /// File holding the metadata bytes
+    #[clap(
+        help = "File holding the entry metadata, at most 2048 bytes",
+        long,
+        conflicts_with = "metadata"
+    )]
+    pub metadata_file: Option<PathBuf>,
+}
+
+impl MetadataArgs {
+    /// Resolves the metadata, reading the file when one was given.
+    ///
+    /// Absent metadata is an empty entry, which the registry accepts: the schema of the bytes
+    /// belongs to the service type, and a type may well define no metadata at all.
+    pub fn read(&self) -> Result<ServiceMetadata, HelperErrors> {
+        match (&self.metadata, &self.metadata_file) {
+            (Some(metadata), _) => Ok(metadata.clone()),
+            (None, Some(path)) => {
+                let bytes = std::fs::read(path).map_err(HelperErrors::UnableToReadFromPath)?;
+                ServiceMetadata::try_from(bytes)
+                    .map_err(|e| HelperErrors::ParseError(format!("invalid service metadata in {path:?}: {e}")))
+            }
+            (None, None) => Ok(ServiceMetadata::default()),
+        }
+    }
+}
+
+/// Where a paginated scan starts and how large its pages are.
+#[derive(Clone, Copy, Debug, Parser)]
+pub struct PaginationArgs {
+    /// Index of the first item read
+    #[clap(help = "Index of the first item to read", long, default_value_t = 0)]
+    pub offset: u64,
+
+    /// Number of items read per page
+    #[clap(help = "Number of items read per page", long, default_value_t = DEFAULT_PAGE_SIZE)]
+    pub page_size: u64,
+}
+
+impl Default for PaginationArgs {
+    fn default() -> Self {
+        Self {
+            offset: 0,
+            page_size: DEFAULT_PAGE_SIZE,
+        }
+    }
+}
+
+/// The `bytes32` service type id as the `HoprServiceRegistry` ABI expects it.
+fn service_type_id(service_type: &ServiceType) -> B256 {
+    B256::from(service_type.as_encoded())
+}
+
+/// Resolves the contract addresses of the selected network, rejecting networks without a registry.
+///
+/// A network with no service registry deployment carries the zero address, and dialling it would
+/// send calls to an account with no code that silently returns empty data.
+fn addresses_with_service_registry(network_provider: &NetworkProviderArgs) -> Result<ContractAddresses, HelperErrors> {
+    let addresses = network_provider.get_network_details_from_name()?.addresses;
+    if addresses.service_registry.is_zero() {
+        return Err(HelperErrors::ContractNotDeployed(format!(
+            "HoprServiceRegistry is not deployed on network {}",
+            network_provider.network
+        )));
+    }
+    Ok(addresses)
+}
+
+/// Resolves the Safe bound to `node`, the only sender the registry accepts for that node's entries.
+async fn bound_safe_of_node<P: Provider>(
+    node_safe_registry_address: Address,
+    node: Address,
+    provider: P,
+) -> Result<Address, HelperErrors> {
+    let node_safe_registry = HoprNodeSafeRegistry::new(node_safe_registry_address, provider);
+    let safe = node_safe_registry
+        .nodeToSafe(node)
+        .call()
+        .await
+        .map_err(|e| HelperErrors::MiddlewareError(format!("failed to read the safe bound to node {node}: {e}")))?;
+
+    if safe.is_zero() {
+        return Err(HelperErrors::MissingParameter(format!(
+            "node {node} is not bound to a safe in the node-safe registry; pass --safe-address to override"
+        )));
+    }
+    Ok(safe)
+}
+
+/// Turns a prepared request into one `Call` leg of a Safe MultiSend.
+fn multisend_leg(tx: TransactionRequest) -> Result<MultisendTransaction, HelperErrors> {
+    let to = tx
+        .to
+        .and_then(|kind| kind.to().copied())
+        .ok_or_else(|| HelperErrors::MissingParameter("transaction payload has no target address".into()))?;
+
+    Ok(MultisendTransaction {
+        encoded_data: tx.input.input().cloned().unwrap_or_default(),
+        tx_operation: SafeTxOperation::Call,
+        to,
+        value: U256::ZERO,
+    })
+}
+
+/// Sends `legs` as one Safe MultiSend from `safe_address`, in the given order.
+async fn send_from_safe(
+    rpc_provider: Arc<RpcProvider>,
+    safe_address: Address,
+    signer_key: ChainKeypair,
+    legs: Vec<TransactionRequest>,
+) -> Result<(), HelperErrors> {
+    let safe = SafeSingleton::new(safe_address, rpc_provider);
+    let (chain_id, safe_nonce) = get_chain_id_and_safe_nonce(safe.clone()).await?;
+    let multisend_txns = legs.into_iter().map(multisend_leg).collect::<Result<Vec<_>, _>>()?;
+
+    send_multisend_safe_transaction_with_threshold_one(
+        safe,
+        signer_key,
+        SAFE_MULTISEND_ADDRESS,
+        multisend_txns,
+        chain_id,
+        safe_nonce,
+    )
+    .await
+}
+
+/// Sends `tx` from the caller's own key and waits for it to be mined.
+async fn send_from_caller(rpc_provider: Arc<RpcProvider>, tx: TransactionRequest) -> Result<(), HelperErrors> {
+    rpc_provider.send_transaction(tx).await?.watch().await?;
+    Ok(())
+}
+
+impl ServiceSubcommands {
+    /// Registers `node` under `service_type`, paying the type's registration burn.
+    ///
+    /// The approval and the registration travel in one MultiSend, approval first: the registry
+    /// pulls the burn inside `selfRegister`, so a separate approval transaction would leave a
+    /// window in which the allowance sits unused on chain.
+    pub async fn execute_register(
+        network_provider: NetworkProviderArgs,
+        service_type: ServiceType,
+        node_address: Address,
+        safe_address: Option<Address>,
+        metadata: ServiceMetadata,
+        private_key: PrivateKeyArgs,
+    ) -> Result<(), HelperErrors> {
+        let signer_private_key = private_key.read_default()?;
+        let addresses = addresses_with_service_registry(&network_provider)?;
+        let rpc_provider = network_provider.get_provider_with_signer(&signer_private_key).await?;
+
+        let safe = match safe_address {
+            Some(safe) => safe,
+            None => bound_safe_of_node(addresses.node_safe_registry, node_address, rpc_provider.clone()).await?,
+        };
+
+        let registry = HoprServiceRegistry::new(addresses.service_registry, rpc_provider.clone());
+        let burn = registry
+            .selfRegistrationBurn(service_type_id(&service_type))
+            .call()
+            .await
+            .map_err(|e| HelperErrors::MiddlewareError(format!("failed to read the registration burn: {e}")))?;
+
+        info!(
+            %service_type, node = %node_address, safe = %safe, burn = %burn,
+            metadata_len = metadata.as_ref().len(),
+            "Registering a service entry through the node's safe"
+        );
+
+        let mut legs = Vec::new();
+        if !burn.is_zero() {
+            legs.push(approve_hopr_token_payload(
+                addresses.token,
+                addresses.service_registry,
+                burn,
+            ));
+        }
+        legs.push(self_register_service_payload(
+            addresses.service_registry,
+            &service_type,
+            node_address,
+            &metadata,
+        ));
+
+        send_from_safe(rpc_provider, safe, signer_private_key, legs).await
+    }
+
+    /// Replaces the metadata of the entry of `node` under `service_type`.
+    ///
+    /// Batched the same way as [`ServiceSubcommands::execute_register`], against the update burn.
+    pub async fn execute_update(
+        network_provider: NetworkProviderArgs,
+        service_type: ServiceType,
+        node_address: Address,
+        safe_address: Option<Address>,
+        metadata: ServiceMetadata,
+        private_key: PrivateKeyArgs,
+    ) -> Result<(), HelperErrors> {
+        let signer_private_key = private_key.read_default()?;
+        let addresses = addresses_with_service_registry(&network_provider)?;
+        let rpc_provider = network_provider.get_provider_with_signer(&signer_private_key).await?;
+
+        let safe = match safe_address {
+            Some(safe) => safe,
+            None => bound_safe_of_node(addresses.node_safe_registry, node_address, rpc_provider.clone()).await?,
+        };
+
+        let registry = HoprServiceRegistry::new(addresses.service_registry, rpc_provider.clone());
+        let burn = registry
+            .selfUpdateBurn(service_type_id(&service_type))
+            .call()
+            .await
+            .map_err(|e| HelperErrors::MiddlewareError(format!("failed to read the update burn: {e}")))?;
+
+        info!(
+            %service_type, node = %node_address, safe = %safe, burn = %burn,
+            metadata_len = metadata.as_ref().len(),
+            "Updating a service entry through the node's safe"
+        );
+
+        let mut legs = Vec::new();
+        if !burn.is_zero() {
+            legs.push(approve_hopr_token_payload(
+                addresses.token,
+                addresses.service_registry,
+                burn,
+            ));
+        }
+        legs.push(self_update_service_payload(
+            addresses.service_registry,
+            &service_type,
+            node_address,
+            &metadata,
+        ));
+
+        send_from_safe(rpc_provider, safe, signer_private_key, legs).await
+    }
+
+    /// Removes the entry of `node` under `service_type`.
+    ///
+    /// No approval leg: deregistration is free by design, so that a bound node can always delist
+    /// itself even when it holds no wxHOPR at all.
+    pub async fn execute_deregister(
+        network_provider: NetworkProviderArgs,
+        service_type: ServiceType,
+        node_address: Address,
+        safe_address: Option<Address>,
+        private_key: PrivateKeyArgs,
+    ) -> Result<(), HelperErrors> {
+        let signer_private_key = private_key.read_default()?;
+        let addresses = addresses_with_service_registry(&network_provider)?;
+        let rpc_provider = network_provider.get_provider_with_signer(&signer_private_key).await?;
+
+        let safe = match safe_address {
+            Some(safe) => safe,
+            None => bound_safe_of_node(addresses.node_safe_registry, node_address, rpc_provider.clone()).await?,
+        };
+
+        info!(
+            %service_type, node = %node_address, safe = %safe,
+            "Deregistering a service entry through the node's safe"
+        );
+
+        let leg = self_deregister_service_payload(addresses.service_registry, &service_type, node_address);
+        send_from_safe(rpc_provider, safe, signer_private_key, vec![leg]).await
+    }
+
+    /// Reads the entry of `node` under `service_type`, if it has one.
+    ///
+    /// The registry returns a zeroed entry for an absent one, which this reports as `None`.
+    pub async fn execute_get_entry(
+        network_provider: NetworkProviderArgs,
+        service_type: ServiceType,
+        node_address: Address,
+    ) -> Result<Option<Entry>, HelperErrors> {
+        let addresses = addresses_with_service_registry(&network_provider)?;
+        let rpc_provider = network_provider.get_provider_without_signer().await?;
+        let registry = HoprServiceRegistry::new(addresses.service_registry, rpc_provider.clone());
+
+        let entry = registry
+            .getEntry(service_type_id(&service_type), node_address)
+            .call()
+            .await
+            .map_err(|e| HelperErrors::MiddlewareError(format!("failed to read the service entry: {e}")))?;
+
+        if entry.registeredAt.is_zero() {
+            info!(%service_type, node = %node_address, "No service entry registered");
+            return Ok(None);
+        }
+
+        info!(
+            %service_type,
+            node = %node_address,
+            registered_at = %entry.registeredAt,
+            updated_at = %entry.updatedAt,
+            metadata = %hex::encode(&entry.metadata),
+            "Service entry"
+        );
+        Ok(Some(entry))
+    }
+
+    /// Lists the entries registered under `service_type`.
+    ///
+    /// Every page is read at the same block: deregistration swap-and-pops the entry list, so a
+    /// scan spread over several blocks can miss an entry or return one twice.
+    pub async fn execute_list_entries(
+        network_provider: NetworkProviderArgs,
+        service_type: ServiceType,
+        pagination: PaginationArgs,
+    ) -> Result<Vec<(Address, Entry)>, HelperErrors> {
+        let page_size = pagination.checked_page_size()?;
+        let addresses = addresses_with_service_registry(&network_provider)?;
+        let rpc_provider = network_provider.get_provider_without_signer().await?;
+        let registry = HoprServiceRegistry::new(addresses.service_registry, rpc_provider.clone());
+
+        let block = BlockId::number(rpc_provider.get_block_number().await?);
+        let service_type_id = service_type_id(&service_type);
+
+        let mut entries: Vec<(Address, Entry)> = Vec::new();
+        let mut cursor = pagination.offset;
+        loop {
+            let page = registry
+                .getEntriesPaginated(service_type_id, U256::from(cursor), U256::from(page_size))
+                .block(block)
+                .call()
+                .await
+                .map_err(|e| HelperErrors::MiddlewareError(format!("failed to read a page of entries: {e}")))?;
+
+            let page_len = page._0.len();
+            entries.extend(page._0.into_iter().zip(page._1));
+
+            if (page_len as u64) < page_size {
+                break;
+            }
+            cursor += page_size;
+        }
+
+        info!(
+            %service_type,
+            count = entries.len(),
+            block = %block,
+            "Listed the entries of a service type"
+        );
+        for (node, entry) in &entries {
+            info!(
+                %service_type,
+                node = %node,
+                registered_at = %entry.registeredAt,
+                updated_at = %entry.updatedAt,
+                metadata = %hex::encode(&entry.metadata),
+                "Service entry"
+            );
+        }
+        Ok(entries)
+    }
+
+    /// Lists the registered service types.
+    ///
+    /// Pinned to a single block for the same reason as [`ServiceSubcommands::execute_list_entries`].
+    pub async fn execute_list_types(
+        network_provider: NetworkProviderArgs,
+        pagination: PaginationArgs,
+    ) -> Result<Vec<ServiceType>, HelperErrors> {
+        let page_size = pagination.checked_page_size()?;
+        let addresses = addresses_with_service_registry(&network_provider)?;
+        let rpc_provider = network_provider.get_provider_without_signer().await?;
+        let registry = HoprServiceRegistry::new(addresses.service_registry, rpc_provider.clone());
+
+        let block = BlockId::number(rpc_provider.get_block_number().await?);
+
+        let mut ids: Vec<B256> = Vec::new();
+        let mut cursor = pagination.offset;
+        loop {
+            let page = registry
+                .getServiceTypesPaginated(U256::from(cursor), U256::from(page_size))
+                .block(block)
+                .call()
+                .await
+                .map_err(|e| HelperErrors::MiddlewareError(format!("failed to read a page of service types: {e}")))?;
+
+            let page_len = page.len();
+            ids.extend(page);
+
+            if (page_len as u64) < page_size {
+                break;
+            }
+            cursor += page_size;
+        }
+
+        let service_types = ids
+            .into_iter()
+            .map(|id| {
+                ServiceType::try_from(id).map_err(|e| HelperErrors::ParseError(format!("invalid service type id: {e}")))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        info!(count = service_types.len(), block = %block, "Listed the service types");
+        for service_type in &service_types {
+            info!(service_type = %service_type, id = %service_type.to_hex(), "Service type");
+        }
+        Ok(service_types)
+    }
+
+    /// Claims `service_type` for the caller, paying the global type registration fee.
+    ///
+    /// The approval is for exactly the fee read a moment earlier, so a fee raised in between
+    /// makes the registration revert on the allowance instead of overpaying.
+    pub async fn execute_register_type(
+        network_provider: NetworkProviderArgs,
+        service_type: ServiceType,
+        requirement: Address,
+        registration_burn: U256,
+        update_burn: U256,
+        private_key: PrivateKeyArgs,
+    ) -> Result<(), HelperErrors> {
+        let signer_private_key = private_key.read_default()?;
+        let addresses = addresses_with_service_registry(&network_provider)?;
+        let rpc_provider = network_provider.get_provider_with_signer(&signer_private_key).await?;
+
+        let registry = HoprServiceRegistry::new(addresses.service_registry, rpc_provider.clone());
+        let fee = registry
+            .typeRegistrationFee()
+            .call()
+            .await
+            .map_err(|e| HelperErrors::MiddlewareError(format!("failed to read the type registration fee: {e}")))?;
+
+        info!(
+            %service_type, %requirement, %registration_burn, %update_burn, %fee,
+            "Registering a service type"
+        );
+
+        if !fee.is_zero() {
+            send_from_caller(
+                rpc_provider.clone(),
+                approve_hopr_token_payload(addresses.token, addresses.service_registry, fee),
+            )
+            .await?;
+        }
+
+        send_from_caller(
+            rpc_provider,
+            register_service_type_payload(
+                addresses.service_registry,
+                &service_type,
+                requirement,
+                registration_burn,
+                update_burn,
+            ),
+        )
+        .await
+    }
+
+    /// Points `service_type` at `requirement`, or opens it up with the zero address.
+    pub async fn execute_set_requirement(
+        network_provider: NetworkProviderArgs,
+        service_type: ServiceType,
+        requirement: Address,
+        private_key: PrivateKeyArgs,
+    ) -> Result<(), HelperErrors> {
+        let signer_private_key = private_key.read_default()?;
+        let addresses = addresses_with_service_registry(&network_provider)?;
+        let rpc_provider = network_provider.get_provider_with_signer(&signer_private_key).await?;
+
+        info!(%service_type, %requirement, "Setting the requirement of a service type");
+        send_from_caller(
+            rpc_provider,
+            set_service_type_requirement_payload(addresses.service_registry, &service_type, requirement),
+        )
+        .await
+    }
+
+    /// Sets the registration burn of `service_type`.
+    pub async fn execute_set_registration_burn(
+        network_provider: NetworkProviderArgs,
+        service_type: ServiceType,
+        amount: U256,
+        private_key: PrivateKeyArgs,
+    ) -> Result<(), HelperErrors> {
+        let signer_private_key = private_key.read_default()?;
+        let addresses = addresses_with_service_registry(&network_provider)?;
+        let rpc_provider = network_provider.get_provider_with_signer(&signer_private_key).await?;
+
+        info!(%service_type, %amount, "Setting the registration burn of a service type");
+        send_from_caller(
+            rpc_provider,
+            set_self_registration_burn_payload(addresses.service_registry, &service_type, amount),
+        )
+        .await
+    }
+
+    /// Sets the update burn of `service_type`.
+    pub async fn execute_set_update_burn(
+        network_provider: NetworkProviderArgs,
+        service_type: ServiceType,
+        amount: U256,
+        private_key: PrivateKeyArgs,
+    ) -> Result<(), HelperErrors> {
+        let signer_private_key = private_key.read_default()?;
+        let addresses = addresses_with_service_registry(&network_provider)?;
+        let rpc_provider = network_provider.get_provider_with_signer(&signer_private_key).await?;
+
+        info!(%service_type, %amount, "Setting the update burn of a service type");
+        send_from_caller(
+            rpc_provider,
+            set_self_update_burn_payload(addresses.service_registry, &service_type, amount),
+        )
+        .await
+    }
+
+    /// Hands ownership of `service_type` to `new_owner`, or abandons the type when `abandon` is set.
+    ///
+    /// Both outcomes are irreversible, and the zero address is only reachable through `abandon`
+    /// so that no typo can abandon a type by accident.
+    pub async fn execute_transfer_type_ownership(
+        network_provider: NetworkProviderArgs,
+        service_type: ServiceType,
+        new_owner: Option<Address>,
+        abandon: bool,
+        private_key: PrivateKeyArgs,
+    ) -> Result<(), HelperErrors> {
+        let new_owner = match (new_owner, abandon) {
+            (Some(_), true) => {
+                return Err(HelperErrors::MissingParameter(
+                    "--new-owner and --abandon are mutually exclusive".into(),
+                ));
+            }
+            (Some(owner), false) if owner.is_zero() => {
+                return Err(HelperErrors::MissingParameter(
+                    "transferring a service type to the zero address abandons it forever; pass --abandon to confirm"
+                        .into(),
+                ));
+            }
+            (Some(owner), false) => owner,
+            (None, true) => Address::ZERO,
+            (None, false) => {
+                return Err(HelperErrors::MissingParameter(
+                    "either --new-owner or --abandon must be given".into(),
+                ));
+            }
+        };
+
+        let signer_private_key = private_key.read_default()?;
+        let addresses = addresses_with_service_registry(&network_provider)?;
+        let rpc_provider = network_provider.get_provider_with_signer(&signer_private_key).await?;
+
+        if abandon {
+            info!(%service_type, "Abandoning a service type; this cannot be undone");
+        } else {
+            info!(%service_type, %new_owner, "Transferring the ownership of a service type");
+        }
+
+        send_from_caller(
+            rpc_provider,
+            transfer_service_type_ownership_payload(addresses.service_registry, &service_type, new_owner),
+        )
+        .await
+    }
+
+    /// Sets the global service type registration fee.
+    pub async fn execute_set_fee(
+        network_provider: NetworkProviderArgs,
+        amount: U256,
+        private_key: PrivateKeyArgs,
+    ) -> Result<(), HelperErrors> {
+        let signer_private_key = private_key.read_default()?;
+        let addresses = addresses_with_service_registry(&network_provider)?;
+        let rpc_provider = network_provider.get_provider_with_signer(&signer_private_key).await?;
+
+        info!(%amount, "Setting the service type registration fee");
+        send_from_caller(
+            rpc_provider,
+            set_type_registration_fee_payload(addresses.service_registry, amount),
+        )
+        .await
+    }
+
+    /// Repoints the registry at another node-safe registry.
+    pub async fn execute_set_node_safe_registry(
+        network_provider: NetworkProviderArgs,
+        node_safe_registry: Address,
+        probe_node: Address,
+        expected_safe: Address,
+        private_key: PrivateKeyArgs,
+    ) -> Result<(), HelperErrors> {
+        let signer_private_key = private_key.read_default()?;
+        let addresses = addresses_with_service_registry(&network_provider)?;
+        let rpc_provider = network_provider.get_provider_with_signer(&signer_private_key).await?;
+
+        info!(
+            %node_safe_registry, %probe_node, %expected_safe,
+            "Repointing the service registry at another node-safe registry"
+        );
+        send_from_caller(
+            rpc_provider,
+            set_node_safe_registry_payload(
+                addresses.service_registry,
+                node_safe_registry,
+                probe_node,
+                expected_safe,
+            ),
+        )
+        .await
+    }
+
+    /// Sweeps stray tokens out of the registry.
+    pub async fn execute_recover_tokens(
+        network_provider: NetworkProviderArgs,
+        token: Address,
+        recipient: Address,
+        private_key: PrivateKeyArgs,
+    ) -> Result<(), HelperErrors> {
+        let signer_private_key = private_key.read_default()?;
+        let addresses = addresses_with_service_registry(&network_provider)?;
+        let rpc_provider = network_provider.get_provider_with_signer(&signer_private_key).await?;
+
+        info!(%token, %recipient, "Recovering tokens from the service registry");
+        send_from_caller(
+            rpc_provider,
+            recover_service_registry_tokens_payload(addresses.service_registry, token, recipient),
+        )
+        .await
+    }
+}
+
+impl PaginationArgs {
+    /// Returns the page size, rejecting zero, which would make a scan loop forever.
+    fn checked_page_size(&self) -> Result<u64, HelperErrors> {
+        if self.page_size == 0 {
+            return Err(HelperErrors::ParseError("--page-size must be greater than zero".into()));
+        }
+        Ok(self.page_size)
+    }
+}
+
+impl Cmd for ServiceSubcommands {
+    fn run(self) -> Result<(), HelperErrors> {
+        Ok(())
+    }
+
+    async fn async_run(self) -> Result<(), HelperErrors> {
+        match self {
+            ServiceSubcommands::Register {
+                network_provider,
+                service_type,
+                node_address,
+                safe_address,
+                metadata,
+                private_key,
+            } => {
+                let metadata = metadata.read()?;
+                ServiceSubcommands::execute_register(
+                    network_provider,
+                    service_type,
+                    node_address,
+                    safe_address,
+                    metadata,
+                    private_key,
+                )
+                .await
+            }
+            ServiceSubcommands::Update {
+                network_provider,
+                service_type,
+                node_address,
+                safe_address,
+                metadata,
+                private_key,
+            } => {
+                let metadata = metadata.read()?;
+                ServiceSubcommands::execute_update(
+                    network_provider,
+                    service_type,
+                    node_address,
+                    safe_address,
+                    metadata,
+                    private_key,
+                )
+                .await
+            }
+            ServiceSubcommands::Deregister {
+                network_provider,
+                service_type,
+                node_address,
+                safe_address,
+                private_key,
+            } => {
+                ServiceSubcommands::execute_deregister(
+                    network_provider,
+                    service_type,
+                    node_address,
+                    safe_address,
+                    private_key,
+                )
+                .await
+            }
+            ServiceSubcommands::Get {
+                network_provider,
+                service_type,
+                node_address,
+            } => {
+                ServiceSubcommands::execute_get_entry(network_provider, service_type, node_address).await?;
+                Ok(())
+            }
+            ServiceSubcommands::List {
+                network_provider,
+                service_type,
+                pagination,
+            } => {
+                ServiceSubcommands::execute_list_entries(network_provider, service_type, pagination).await?;
+                Ok(())
+            }
+            ServiceSubcommands::Types {
+                network_provider,
+                pagination,
+            } => {
+                ServiceSubcommands::execute_list_types(network_provider, pagination).await?;
+                Ok(())
+            }
+            ServiceSubcommands::RegisterType {
+                network_provider,
+                service_type,
+                requirement,
+                registration_burn,
+                update_burn,
+                private_key,
+            } => {
+                ServiceSubcommands::execute_register_type(
+                    network_provider,
+                    service_type,
+                    requirement,
+                    registration_burn,
+                    update_burn,
+                    private_key,
+                )
+                .await
+            }
+            ServiceSubcommands::SetRequirement {
+                network_provider,
+                service_type,
+                requirement,
+                private_key,
+            } => {
+                ServiceSubcommands::execute_set_requirement(network_provider, service_type, requirement, private_key)
+                    .await
+            }
+            ServiceSubcommands::SetRegistrationBurn {
+                network_provider,
+                service_type,
+                amount,
+                private_key,
+            } => {
+                ServiceSubcommands::execute_set_registration_burn(network_provider, service_type, amount, private_key)
+                    .await
+            }
+            ServiceSubcommands::SetUpdateBurn {
+                network_provider,
+                service_type,
+                amount,
+                private_key,
+            } => ServiceSubcommands::execute_set_update_burn(network_provider, service_type, amount, private_key).await,
+            ServiceSubcommands::TransferTypeOwnership {
+                network_provider,
+                service_type,
+                new_owner,
+                abandon,
+                private_key,
+            } => {
+                ServiceSubcommands::execute_transfer_type_ownership(
+                    network_provider,
+                    service_type,
+                    new_owner,
+                    abandon,
+                    private_key,
+                )
+                .await
+            }
+            ServiceSubcommands::SetFee {
+                network_provider,
+                amount,
+                private_key,
+            } => ServiceSubcommands::execute_set_fee(network_provider, amount, private_key).await,
+            ServiceSubcommands::SetNodeSafeRegistry {
+                network_provider,
+                node_safe_registry,
+                probe_node,
+                expected_safe,
+                private_key,
+            } => {
+                ServiceSubcommands::execute_set_node_safe_registry(
+                    network_provider,
+                    node_safe_registry,
+                    probe_node,
+                    expected_safe,
+                    private_key,
+                )
+                .await
+            }
+            ServiceSubcommands::RecoverTokens {
+                network_provider,
+                token,
+                recipient,
+                private_key,
+            } => ServiceSubcommands::execute_recover_tokens(network_provider, token, recipient, private_key).await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use hopr_bindings::config::{ContractInstances, NetworksWithContractAddresses, SingleNetworkContractAddresses};
+    use hopr_types::{crypto::keypairs::Keypair, primitive::prelude::BytesRepresentable};
+
+    use super::*;
+    use crate::{
+        methods::{create_rpc_client_to_anvil, deploy_safe_module_with_targets_and_nodes},
+        utils::{a2h, create_anvil},
+    };
+
+    #[test]
+    fn test_parse_service_type_accepts_an_ascii_name() -> anyhow::Result<()> {
+        assert_eq!(
+            parse_service_type("gvpn:exit").map_err(anyhow::Error::msg)?,
+            ServiceType::GVPN_EXIT
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_service_type_accepts_a_name_of_the_full_width() {
+        let name = "a".repeat(ServiceType::SIZE);
+        assert!(parse_service_type(&name).is_ok(), "a 32 byte name should be accepted");
+    }
+
+    #[test]
+    fn test_parse_service_type_rejects_a_name_wider_than_the_id() {
+        // 33 bytes: one over what a `bytes32` can hold.
+        let name = "a".repeat(ServiceType::SIZE + 1);
+        assert!(parse_service_type(&name).is_err(), "a 33 byte name should be rejected");
+    }
+
+    #[test]
+    fn test_parse_service_type_rejects_non_ascii() {
+        assert!(parse_service_type("gvpn:exït").is_err(), "non-ASCII should be rejected");
+    }
+
+    #[test]
+    fn test_parse_service_type_rejects_a_space() {
+        // A space is indistinguishable from the right padding, so it is not a usable identifier.
+        assert!(parse_service_type("gvpn exit").is_err(), "a space should be rejected");
+    }
+
+    #[test]
+    fn test_parse_service_type_rejects_empty() {
+        assert!(parse_service_type("").is_err(), "an empty name should be rejected");
+    }
+
+    #[test]
+    fn test_parse_service_type_accepts_a_hex_id() -> anyhow::Result<()> {
+        let id = "0x6776706e3a657869740000000000000000000000000000000000000000000000";
+        assert_eq!(
+            parse_service_type(id).map_err(anyhow::Error::msg)?,
+            ServiceType::GVPN_EXIT
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_service_type_rejects_the_zero_hex_id() {
+        let id = format!("0x{}", "00".repeat(ServiceType::SIZE));
+        assert!(parse_service_type(&id).is_err(), "the zero id should be rejected");
+    }
+
+    #[test]
+    fn test_parse_service_type_rejects_a_hex_id_of_the_wrong_width() {
+        // 33 bytes of hex: the `0x` prefix commits to the hex reading, so this cannot fall back
+        // to being read as a name.
+        let id = format!("0x{}", "11".repeat(ServiceType::SIZE + 1));
+        assert!(parse_service_type(&id).is_err(), "a 33 byte id should be rejected");
+    }
+
+    #[test]
+    fn test_parse_service_metadata_accepts_the_maximum_length() -> anyhow::Result<()> {
+        let metadata = "x".repeat(ServiceMetadata::MAX_LENGTH);
+        let parsed = parse_service_metadata(&metadata).map_err(anyhow::Error::msg)?;
+        assert_eq!(parsed.as_ref().len(), ServiceMetadata::MAX_LENGTH);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_service_metadata_rejects_one_byte_over_the_maximum() {
+        let metadata = "x".repeat(ServiceMetadata::MAX_LENGTH + 1);
+        assert!(
+            parse_service_metadata(&metadata).is_err(),
+            "2049 bytes of metadata should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_parse_service_metadata_accepts_empty() -> anyhow::Result<()> {
+        assert_eq!(
+            parse_service_metadata("").map_err(anyhow::Error::msg)?,
+            ServiceMetadata::default()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_metadata_args_read_prefers_the_inline_value() -> anyhow::Result<()> {
+        let args = MetadataArgs {
+            metadata: Some(ServiceMetadata::try_from(b"inline".to_vec())?),
+            metadata_file: None,
+        };
+        assert_eq!(args.read()?.as_ref(), b"inline");
+        Ok(())
+    }
+
+    #[test]
+    fn test_metadata_args_read_reads_a_file() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("metadata.bin");
+        // Not valid UTF-8, which is exactly what the file form exists for.
+        std::fs::write(&path, [0xffu8, 0xfe, 0x00, 0x01])?;
+
+        let args = MetadataArgs {
+            metadata: None,
+            metadata_file: Some(path),
+        };
+        assert_eq!(args.read()?.as_ref(), [0xffu8, 0xfe, 0x00, 0x01]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_metadata_args_read_rejects_a_file_over_the_maximum() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("metadata.bin");
+        std::fs::write(&path, vec![0u8; ServiceMetadata::MAX_LENGTH + 1])?;
+
+        let args = MetadataArgs {
+            metadata: None,
+            metadata_file: Some(path),
+        };
+        let err = args.read().expect_err("an oversized file should be rejected");
+        assert!(
+            matches!(err, HelperErrors::ParseError(_)),
+            "expected ParseError, got {err:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_metadata_args_read_defaults_to_empty() -> anyhow::Result<()> {
+        let args = MetadataArgs {
+            metadata: None,
+            metadata_file: None,
+        };
+        assert_eq!(args.read()?, ServiceMetadata::default());
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_hopr_amount_converts_whole_tokens_to_wei() -> anyhow::Result<()> {
+        assert_eq!(
+            parse_hopr_amount("1.5").map_err(anyhow::Error::msg)?,
+            U256::from(1_500_000_000_000_000_000u64)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_hopr_amount_rejects_a_non_number() {
+        assert!(parse_hopr_amount("many").is_err(), "a non-number should be rejected");
+    }
+
+    #[test]
+    fn test_checked_page_size_rejects_zero() {
+        // A zero page size would return an empty page forever and never terminate the scan.
+        let err = PaginationArgs {
+            offset: 0,
+            page_size: 0,
+        }
+        .checked_page_size()
+        .expect_err("a zero page size should be rejected");
+        assert!(
+            matches!(err, HelperErrors::ParseError(_)),
+            "expected ParseError, got {err:?}"
+        );
+    }
+
+    /// The `--network` and `--provider-url` pair every on-chain subcommand needs.
+    fn network_args() -> [&'static str; 4] {
+        [
+            "--network",
+            "anvil-localhost",
+            "--provider-url",
+            "http://127.0.0.1:8545",
+        ]
+    }
+
+    #[test]
+    fn test_cli_parses_register() -> anyhow::Result<()> {
+        let parsed =
+            ServiceSubcommands::try_parse_from(["hopli", "register"].into_iter().chain(network_args()).chain([
+                "--service-type",
+                "gvpn:exit",
+                "--node-address",
+                "0x00000000000000000000000000000000000000aa",
+                "--metadata",
+                "hello",
+                "--private-key",
+                "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+            ]))?;
+
+        match parsed {
+            ServiceSubcommands::Register {
+                service_type,
+                node_address,
+                safe_address,
+                metadata,
+                ..
+            } => {
+                assert_eq!(service_type, ServiceType::GVPN_EXIT);
+                assert_eq!(
+                    node_address,
+                    Address::new(hex_literal::hex!("00000000000000000000000000000000000000aa"))
+                );
+                assert_eq!(safe_address, None, "the safe defaults to the node's binding");
+                assert_eq!(metadata.read()?.as_ref(), b"hello");
+            }
+            other => panic!("expected Register, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_cli_rejects_metadata_given_twice() {
+        let result =
+            ServiceSubcommands::try_parse_from(["hopli", "register"].into_iter().chain(network_args()).chain([
+                "--service-type",
+                "gvpn:exit",
+                "--node-address",
+                "0x00000000000000000000000000000000000000aa",
+                "--metadata",
+                "hello",
+                "--metadata-file",
+                "./metadata.bin",
+            ]));
+        assert!(result.is_err(), "--metadata and --metadata-file should conflict");
+    }
+
+    #[test]
+    fn test_cli_parses_the_abandon_flag() -> anyhow::Result<()> {
+        let parsed = ServiceSubcommands::try_parse_from(
+            ["hopli", "transfer-type-ownership"]
+                .into_iter()
+                .chain(network_args())
+                .chain(["--service-type", "gvpn:exit"])
+                .chain(["--abandon"]),
+        )?;
+
+        match parsed {
+            ServiceSubcommands::TransferTypeOwnership { new_owner, abandon, .. } => {
+                assert_eq!(new_owner, None);
+                assert!(abandon);
+            }
+            other => panic!("expected TransferTypeOwnership, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_cli_transfer_type_ownership_needs_a_target() {
+        let result = ServiceSubcommands::try_parse_from(
+            ["hopli", "transfer-type-ownership"]
+                .into_iter()
+                .chain(network_args())
+                .chain(["--service-type", "gvpn:exit"]),
+        );
+        assert!(result.is_err(), "one of --new-owner and --abandon should be required");
+    }
+
+    #[test]
+    fn test_cli_rejects_a_new_owner_together_with_abandon() {
+        let result = ServiceSubcommands::try_parse_from(
+            ["hopli", "transfer-type-ownership"]
+                .into_iter()
+                .chain(network_args())
+                .chain([
+                    "--service-type",
+                    "gvpn:exit",
+                    "--new-owner",
+                    "0x00000000000000000000000000000000000000cc",
+                    "--abandon",
+                ]),
+        );
+        assert!(result.is_err(), "--new-owner and --abandon should conflict");
+    }
+
+    #[test]
+    fn test_cli_parses_register_type_burns_as_whole_tokens() -> anyhow::Result<()> {
+        let parsed =
+            ServiceSubcommands::try_parse_from(["hopli", "register-type"].into_iter().chain(network_args()).chain([
+                "--service-type",
+                "gvpn:exit",
+                "--registration-burn",
+                "1",
+                "--update-burn",
+                "0.5",
+            ]))?;
+
+        match parsed {
+            ServiceSubcommands::RegisterType {
+                requirement,
+                registration_burn,
+                update_burn,
+                ..
+            } => {
+                assert_eq!(requirement, Address::ZERO, "a type is open unless told otherwise");
+                assert_eq!(registration_burn, U256::from(1_000_000_000_000_000_000u64));
+                assert_eq!(update_burn, U256::from(500_000_000_000_000_000u64));
+            }
+            other => panic!("expected RegisterType, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_cli_pagination_defaults_to_a_full_scan_from_the_start() -> anyhow::Result<()> {
+        let parsed = ServiceSubcommands::try_parse_from(
+            ["hopli", "list"]
+                .into_iter()
+                .chain(network_args())
+                .chain(["--service-type", "gvpn:exit"]),
+        )?;
+
+        match parsed {
+            ServiceSubcommands::List { pagination, .. } => {
+                assert_eq!(pagination.offset, 0);
+                assert_eq!(pagination.page_size, DEFAULT_PAGE_SIZE);
+            }
+            other => panic!("expected List, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_transfer_type_ownership_needs_abandon_for_the_zero_address() {
+        let err = ServiceSubcommands::execute_transfer_type_ownership(
+            NetworkProviderArgs::default(),
+            ServiceType::GVPN_EXIT,
+            Some(Address::ZERO),
+            false,
+            PrivateKeyArgs::default(),
+        )
+        .await
+        .expect_err("a zero new owner without --abandon should be rejected");
+        assert!(
+            matches!(err, HelperErrors::MissingParameter(_)),
+            "expected MissingParameter, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_transfer_type_ownership_needs_a_target() {
+        let err = ServiceSubcommands::execute_transfer_type_ownership(
+            NetworkProviderArgs::default(),
+            ServiceType::GVPN_EXIT,
+            None,
+            false,
+            PrivateKeyArgs::default(),
+        )
+        .await
+        .expect_err("neither --new-owner nor --abandon should be rejected");
+        assert!(
+            matches!(err, HelperErrors::MissingParameter(_)),
+            "expected MissingParameter, got {err:?}"
+        );
+    }
+
+    /// Writes a `contracts-addresses.json` describing one network and returns its root directory.
+    fn write_contracts_root(
+        dir: &tempfile::TempDir,
+        chain_id: u64,
+        addresses: ContractAddresses,
+    ) -> anyhow::Result<String> {
+        let mut networks = BTreeMap::new();
+        networks.insert(
+            "anvil-localhost".to_string(),
+            SingleNetworkContractAddresses {
+                chain_id,
+                indexer_start_block_number: 0u32,
+                addresses,
+            },
+        );
+        std::fs::write(
+            dir.path().join("contracts-addresses.json"),
+            serde_json::to_string_pretty(&NetworksWithContractAddresses { networks })?,
+        )?;
+        Ok(dir.path().to_str().expect("temp dir path is not utf-8").to_string())
+    }
+
+    #[test]
+    fn test_addresses_with_service_registry_rejects_a_network_without_a_deployment() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let addresses = ContractAddresses {
+            service_registry: Address::ZERO,
+            ..Default::default()
+        };
+        let contracts_root = write_contracts_root(&dir, 31337, addresses)?;
+
+        let args = NetworkProviderArgs {
+            contracts_root: Some(contracts_root),
+            ..Default::default()
+        };
+        let err = addresses_with_service_registry(&args).expect_err("a zero address should be rejected");
+        assert!(
+            matches!(err, HelperErrors::ContractNotDeployed(_)),
+            "expected ContractNotDeployed, got {err:?}"
+        );
+        Ok(())
+    }
+
+    /// Drives one entry through its whole life against a local anvil.
+    ///
+    /// The registration and update burns are deliberately non-zero, which is what makes this a
+    /// test of the MultiSend ordering: the registry pulls the burn inside `selfRegister` and
+    /// `selfUpdate`, so both calls revert - taking the whole Safe transaction with them - unless
+    /// the approval leg really does run first, in the same transaction, for at least the burn.
+    #[tokio::test]
+    async fn test_service_entry_lifecycle_through_the_bound_safe() -> anyhow::Result<()> {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let registration_burn = U256::from(2_000_000_000_000_000_000u64); // 2 wxHOPR
+        let update_burn = U256::from(1_000_000_000_000_000_000u64); // 1 wxHOPR
+
+        // launch anvil and deploy the HOPR contracts, multicall and the safe suites
+        let anvil = create_anvil(None);
+        let contract_deployer = ChainKeypair::from_secret(anvil.keys()[0].to_bytes().as_ref())?;
+        let client = create_rpc_client_to_anvil(&anvil, &contract_deployer);
+        let instances = ContractInstances::deploy_for_testing(
+            client.clone(),
+            a2h(contract_deployer.public().to_address()),
+            anvil.addresses()[1],
+        )
+        .await
+        .expect("failed to deploy");
+        ContractInstances::deploy_multicall3(client.clone(), anvil.addresses()[1]).await?;
+        ContractInstances::deploy_safe_suites(client.clone(), anvil.addresses()[1]).await?;
+
+        let node = a2h(contract_deployer.public().to_address());
+        let contract_addresses = instances.get_contract_addresses();
+        let channels_address = *instances.channels.address();
+        let token = instances.token.clone();
+        let service_registry = instances.service_registry.clone();
+
+        // the deployer owns the safe and is also the node it registers
+        let (safe, _module) = deploy_safe_module_with_targets_and_nodes(
+            instances.stake_factory,
+            channels_address,
+            vec![node],
+            vec![node],
+            U256::from(1),
+        )
+        .await?;
+
+        // bind the node to the safe: the registry accepts writes from that safe and no other
+        instances
+            .safe_registry
+            .registerSafeByNode(*safe.address())
+            .send()
+            .await?
+            .watch()
+            .await?;
+
+        // the safe pays the burns, so it needs the tokens.
+        //
+        // This is the last transaction sent through `client`. The commands below each build their
+        // own provider, with their own nonce cache, so a later `client` transaction would reuse a
+        // nonce the chain has already seen.
+        token
+            .transfer(*safe.address(), registration_burn + update_burn)
+            .send()
+            .await?
+            .watch()
+            .await?;
+        let safe_balance_before = token.balanceOf(*safe.address()).call().await?;
+
+        let temp_dir = tempfile::tempdir()?;
+        let contracts_root = write_contracts_root(&temp_dir, anvil.chain_id(), contract_addresses)?;
+        let network_provider = NetworkProviderArgs {
+            network: "anvil-localhost".into(),
+            contracts_root: Some(contracts_root),
+            provider_url: anvil.endpoint(),
+        };
+        let private_key = PrivateKeyArgs {
+            private_key: Some(hex::encode(contract_deployer.secret().as_ref())),
+        };
+
+        // claim an open service type with non-zero burns, paying the global registration fee
+        ServiceSubcommands::execute_register_type(
+            network_provider.clone(),
+            ServiceType::GVPN_EXIT,
+            Address::ZERO,
+            registration_burn,
+            update_burn,
+            private_key.clone(),
+        )
+        .await?;
+
+        assert_eq!(
+            ServiceSubcommands::execute_list_types(network_provider.clone(), PaginationArgs::default()).await?,
+            vec![ServiceType::GVPN_EXIT],
+            "the claimed type should be the only registered one"
+        );
+
+        // register the entry through the safe
+        let metadata = ServiceMetadata::try_from(br#"{"endpoint":"https://exit.example"}"#.to_vec())?;
+        ServiceSubcommands::execute_register(
+            network_provider.clone(),
+            ServiceType::GVPN_EXIT,
+            node,
+            None,
+            metadata.clone(),
+            private_key.clone(),
+        )
+        .await?;
+
+        let entry = ServiceSubcommands::execute_get_entry(network_provider.clone(), ServiceType::GVPN_EXIT, node)
+            .await?
+            .expect("the entry should exist after registering");
+        assert_eq!(entry.metadata.to_vec(), metadata.as_ref(), "metadata should round trip");
+        assert!(
+            !entry.registeredAt.is_zero(),
+            "a registered entry has a registration time"
+        );
+        assert_eq!(
+            entry.updatedAt, entry.registeredAt,
+            "registration sets updatedAt to registeredAt"
+        );
+
+        assert_eq!(
+            token.balanceOf(*safe.address()).call().await?,
+            safe_balance_before - registration_burn,
+            "exactly the registration burn should have left the safe"
+        );
+        assert!(
+            token
+                .allowance(*safe.address(), *service_registry.address())
+                .call()
+                .await?
+                .is_zero(),
+            "the exact approval should be fully consumed, leaving no standing allowance"
+        );
+
+        let registered = service_registry.Registered_filter().from_block(0).query().await?;
+        assert_eq!(registered.len(), 1, "one Registered event should have been emitted");
+        assert_eq!(registered[0].0.node, node);
+        assert_eq!(registered[0].0.safe, *safe.address());
+        assert_eq!(registered[0].0.serviceType, service_type_id(&ServiceType::GVPN_EXIT));
+        assert_eq!(registered[0].0.metadata.to_vec(), metadata.as_ref());
+        assert_eq!(registered[0].0.burned, registration_burn);
+
+        let listed = ServiceSubcommands::execute_list_entries(
+            network_provider.clone(),
+            ServiceType::GVPN_EXIT,
+            PaginationArgs::default(),
+        )
+        .await?;
+        assert_eq!(listed.len(), 1, "the type should list exactly the one entry");
+        assert_eq!(listed[0].0, node);
+        assert_eq!(listed[0].1.metadata.to_vec(), metadata.as_ref());
+
+        // update the entry through the safe
+        let new_metadata = ServiceMetadata::try_from(br#"{"endpoint":"https://exit2.example"}"#.to_vec())?;
+        ServiceSubcommands::execute_update(
+            network_provider.clone(),
+            ServiceType::GVPN_EXIT,
+            node,
+            None,
+            new_metadata.clone(),
+            private_key.clone(),
+        )
+        .await?;
+
+        let updated = ServiceSubcommands::execute_get_entry(network_provider.clone(), ServiceType::GVPN_EXIT, node)
+            .await?
+            .expect("the entry should still exist after updating");
+        assert_eq!(
+            updated.metadata.to_vec(),
+            new_metadata.as_ref(),
+            "the new metadata should have replaced the old one"
+        );
+        assert_eq!(
+            updated.registeredAt, entry.registeredAt,
+            "an update leaves the registration time untouched"
+        );
+
+        assert_eq!(
+            token.balanceOf(*safe.address()).call().await?,
+            safe_balance_before - registration_burn - update_burn,
+            "exactly the update burn should have left the safe"
+        );
+
+        let updates = service_registry.Updated_filter().from_block(0).query().await?;
+        assert_eq!(updates.len(), 1, "one Updated event should have been emitted");
+        assert_eq!(updates[0].0.metadata.to_vec(), new_metadata.as_ref());
+        assert_eq!(updates[0].0.burned, update_burn);
+
+        // deregister the entry through the safe; the safe holds no wxHOPR at this point, which is
+        // exactly the case invariant I6 protects
+        assert!(
+            token.balanceOf(*safe.address()).call().await?.is_zero(),
+            "the safe should have spent all of its wxHOPR on the burns"
+        );
+        ServiceSubcommands::execute_deregister(
+            network_provider.clone(),
+            ServiceType::GVPN_EXIT,
+            node,
+            None,
+            private_key.clone(),
+        )
+        .await?;
+
+        assert!(
+            ServiceSubcommands::execute_get_entry(network_provider.clone(), ServiceType::GVPN_EXIT, node)
+                .await?
+                .is_none(),
+            "the entry should be gone after deregistering"
+        );
+        assert!(
+            ServiceSubcommands::execute_list_entries(
+                network_provider.clone(),
+                ServiceType::GVPN_EXIT,
+                PaginationArgs::default()
+            )
+            .await?
+            .is_empty(),
+            "the type should list no entries after deregistering"
+        );
+
+        let deregistered = service_registry.Deregistered_filter().from_block(0).query().await?;
+        assert_eq!(deregistered.len(), 1, "one Deregistered event should have been emitted");
+        assert_eq!(deregistered[0].0.node, node);
+        assert_eq!(deregistered[0].0.safe, *safe.address());
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
- Adds the `hopli service` command group: entry writes (`register`, `update`, `deregister`),
  type-owner and admin writes, and paginated reads.
- Entry writes go through the Safe that is bound to the node. `register` and `update` batch an
  exact wxHOPR approval with the call, and `deregister` needs no approval.
- Documents the commands in the README and bumps the crate to 0.19.0.

## Depends on

- hoprnet/contracts#137 - this branch pins `hopr-bindings` to its git rev.
- hoprnet/hopr-types#104 - this branch pins `hopr-types` to its git rev.

## Follow-up

- [ ] After both PRs above merge and `hopr-bindings` 4.12.2 and `hopr-types` 2.3.0 are
      published, replace the two `git`/`rev` pins in `Cargo.toml` with version requirements.
