### PR TITLE
feat(identity): add migrate subcommand to check and upgrade keystore …

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ Convert peer ID/public key:
 hopli identity convert-peer --peer-or-key 16Uiu2HAm...
 ```
 
+Check and migrate identities to the latest keystore format:
+
+```bash
+hopli identity migrate \
+  --identity-directory ./identities \
+  --identity-prefix node_ \
+  --password-path ./secrets/identity.pwd
+```
+
 ### 2. Faucet funding
 
 Fund identities and/or explicit addresses:

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -34,6 +34,14 @@
 //!     --password-path "./test/pwd" \
 //!     --new-password-path "./test/newpwd"
 //! ```
+//!
+//! - To check and migrate identities to the latest keystore format
+//! ```text
+//! hopli identity migrate \
+//!     --identity-directory "./test" \
+//!     --identity-prefix node_ \
+//!     --password-path "./test/pwd"
+//! ```
 use std::{collections::HashMap, str::FromStr};
 
 use clap::{Parser, builder::RangedU64ValueParser};
@@ -49,8 +57,8 @@ use tracing::{debug, info};
 
 use crate::{
     key_pair::{
-        ArgEnvReader, IdentityFileArgs, NewPasswordArgs, create_identity, read_identities, read_identity,
-        update_identity_password,
+        ArgEnvReader, IdentityFileArgs, NewPasswordArgs, create_identity, migrate_identity, read_identities,
+        read_identity, update_identity_password,
     },
     utils::{Cmd, HelperErrors, HelperErrors::UnableToParseAddress},
 };
@@ -94,6 +102,14 @@ pub enum IdentitySubcommands {
         /// New password
         #[command(flatten)]
         new_password: NewPasswordArgs,
+    },
+
+    /// Check identity files for pending keystore-format migrations and migrate them in place
+    #[command(visible_alias = "mg")]
+    Migrate {
+        /// Arguments to locate identity file(s) of HOPR node(s)
+        #[command(flatten)]
+        local_identity: IdentityFileArgs,
     },
 
     /// Converts PeerId from base58 to public key as hex or vice-versa
@@ -207,6 +223,28 @@ impl IdentitySubcommands {
         info!("Updated password for {:?} identity files", files.len());
         Ok(())
     }
+
+    /// check identity files for pending keystore-format migrations and migrate them in place
+    fn execute_identity_migration(local_identity: IdentityFileArgs) -> Result<(), HelperErrors> {
+        // check if password is provided
+        let pwd = local_identity.clone().password.read_default()?;
+
+        // read ids
+        let files = local_identity.get_files()?;
+        debug!("Identities read {:?}", files.len());
+
+        for file in &files {
+            let migrated = migrate_identity(file, &pwd)?;
+            println!(
+                "{}: {}",
+                file.display(),
+                if migrated { "migrated" } else { "up to date" }
+            );
+        }
+
+        info!("Checked {:?} identity files for migration", files.len());
+        Ok(())
+    }
 }
 
 impl Cmd for IdentitySubcommands {
@@ -223,6 +261,9 @@ impl Cmd for IdentitySubcommands {
                 local_identity,
                 new_password,
             } => IdentitySubcommands::execute_identity_update(local_identity, new_password),
+            IdentitySubcommands::Migrate { local_identity } => {
+                IdentitySubcommands::execute_identity_migration(local_identity)
+            }
             IdentitySubcommands::ConvertPeer { peer_or_key } => {
                 let peer_or_key = peer_or_key.peer_or_key;
                 if peer_or_key.to_lowercase().starts_with("0x") {

--- a/src/key_pair.rs
+++ b/src/key_pair.rs
@@ -81,6 +81,34 @@ pub fn read_identities(files: Vec<PathBuf>, password: &str) -> Result<HashMap<St
     Ok(results)
 }
 
+/// Check whether an identity file needs a keystore-format migration, migrate it in place if so,
+/// and verify the migration preserved the public keys. Returns whether a migration was performed.
+pub fn migrate_identity(file: &Path, password: &str) -> Result<bool, HelperErrors> {
+    let file_str = file
+        .to_str()
+        .ok_or(HelperErrors::IncorrectFilename(file.to_string_lossy().to_string()))?;
+
+    let (before, needs_migration) =
+        HoprKeys::read_eth_keystore(file_str, password).map_err(|_| HelperErrors::UnableToReadIdentity)?;
+
+    if !needs_migration {
+        return Ok(false);
+    }
+
+    before
+        .write_eth_keystore(file_str, password)
+        .map_err(HelperErrors::KeyStoreError)?;
+
+    let (after, still_needs_migration) =
+        HoprKeys::read_eth_keystore(file_str, password).map_err(|_| HelperErrors::UnableToReadIdentity)?;
+
+    if still_needs_migration || before != after {
+        return Err(HelperErrors::MigrationVerificationFailed(file_str.to_string()));
+    }
+
+    Ok(true)
+}
+
 /// encrypt HoprKeys with a new password to an identity file
 pub fn update_identity_password(
     keys: HoprKeys,
@@ -536,6 +564,61 @@ mod tests {
             read_id.chain_key.public().to_address(),
             address,
             "cannot use the new password to read files"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn migrate_identity_not_needed_for_current_format() -> anyhow::Result<()> {
+        let tmp = tempdir()?;
+        let path = tmp.path().to_str().context("should produce a valid tmp path string")?;
+        let pwd = "password";
+        let (_, created_id) = create_identity(path, pwd, &None)?;
+
+        let files = get_files(path, &None);
+        assert_eq!(files.len(), 1, "must have one identity file");
+
+        assert!(
+            !migrate_identity(files[0].as_path(), pwd)?,
+            "current-format identity should not need migration"
+        );
+
+        // re-reading must still yield the same keys
+        let (_, read_id) = read_identity(files[0].as_path(), pwd)?;
+        assert_eq!(
+            read_id.chain_key.public().to_address(),
+            created_id.chain_key.public().to_address()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn migrate_identity_migrates_legacy_keystore() -> anyhow::Result<()> {
+        let tmp = tempdir()?;
+        let path = tmp.path().join("legacy.id");
+        let pwd = "local";
+
+        // V1 raw-private-key keystore fixture, taken from hopr-types' own `test_auto_migration` test
+        let legacy_keystore = r#"{"id":"8e5fe142-6ef9-4fbb-aae8-5de32b680e31","version":3,"crypto":{"cipher":"aes-128-ctr","cipherparams":{"iv":"04141354edb9dfb0c65e6905a3a0b9dd"},"ciphertext":"74f12f72cf2d3d73ff09f783cb9b57995b3808f7d3f71aa1fa1968696aedfbdd","kdf":"scrypt","kdfparams":{"salt":"f5e3f04eaa0c9efffcb5168c6735d7e1fe4d96f48a636c4f00107e7c34722f45","n":1,"dklen":32,"p":1,"r":8},"mac":"d0daf0e5d14a2841f0f7221014d805addfb7609d85329d4c6424a098e50b6fbe"}}"#;
+        fs::write(&path, legacy_keystore.as_bytes())?;
+
+        assert!(migrate_identity(&path, pwd)?, "legacy keystore should need migration");
+
+        let (migrated, still_needs_migration) =
+            HoprKeys::read_eth_keystore(path.to_str().context("should produce a valid tmp path string")?, pwd)?;
+        assert!(
+            !still_needs_migration,
+            "re-read after migration must not need further migration"
+        );
+        assert_eq!(
+            migrated.chain_key.public().to_address().to_string(),
+            "0x826a1bf3d51fa7f402a1e01d1b2c8a8bac28e666"
+        );
+
+        // running migration again on the now-current-format file is a no-op
+        assert!(
+            !migrate_identity(&path, pwd)?,
+            "already-migrated identity should not need migration again"
         );
         Ok(())
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -76,6 +76,10 @@ pub enum HelperErrors {
     #[error("unable to update identity password")]
     UnableToUpdateIdentityPassword,
 
+    /// Migration re-read still needs migration, or public keys changed unexpectedly
+    #[error("migration of identity file {0} did not fully complete or keys changed unexpectedly")]
+    MigrationVerificationFailed(String),
+
     /// Error due to supplying a non-existing file name
     #[error("incorrect filename: {0}")]
     IncorrectFilename(String),


### PR DESCRIPTION
…format

Ports the standalone hopr-id-migrate helper's check/migrate/verify logic into hopli as `hopli identity migrate` (alias `mg`), reusing the existing IdentityFileArgs/PasswordArgs plumbing.